### PR TITLE
Initial Hospitication package: read-only health observer, analyzers, signal pipeline, reporters, CLI, and tests

### DIFF
--- a/hospitication/README.md
+++ b/hospitication/README.md
@@ -1,302 +1,102 @@
-Hospitication
+# Hospitication
 
-Structural Recovery & Signal Stability Framework
+Structural Recovery & Signal Stability Framework for the W3 ecosystem.
 
-«“Do not rewrite truth.
-Recover structural integrity.”»
+> Do not rewrite truth. Recover structural integrity.
 
----
+Hospitication is a production-oriented health observer for W3 repositories. It is
+not a linter and it is not a demo monitor. It observes structural pressure across
+memory, governance, protocol, replay, outcome, and coordination surfaces, emits
+immutable signals, and produces non-mutating recovery proposals.
 
-Overview
+## Scope
 
-Hospitication is a structural recovery framework designed to observe, preserve, and recover system integrity without mutating historical truth.
+Hospitication separates the pipeline into explicit layers:
 
-Unlike traditional monitoring systems that focus on logs, alerts, or runtime failures, Hospitication treats software systems as evolving causal structures with:
+1. **Observe** — read repository structure without mutation.
+2. **Detect** — identify drift, spikes, oscillation, or divergence.
+3. **Emit** — convert detections into immutable signal envelopes.
+4. **Evaluate** — compute health/burden metrics.
+5. **Recover** — propose mitigation only; never apply changes by default.
+6. **Report** — render deterministic Markdown or JSON without changing state.
 
-- pressure
-- instability
-- replayable history
-- structural fatigue
-- semantic drift
+## Production Guarantees
 
-The system is designed around the philosophy that:
+- Uses Python standard library only.
+- Truth/signal/report contracts use immutable dataclasses where appropriate.
+- Reports are deterministic by sorted ordering and configurable fixed timestamp.
+- Recovery proposals are non-destructive and have `destructive=False`.
+- Existing W3 memory/governance/replay files are observed but not rewritten.
+- Signal detection never diagnoses root cause.
+- Detector modules never call recovery modules.
+- Reporter modules never mutate repository state.
 
-signal != logging
-signal = structural nervous response
+## Package Layout
 
----
-
-Core Philosophy
-
-1. Recovery over Rewrite
-
-Hospitication never rewrites historical truth.
-
-Recovery is performed through:
-
-- derived signals
-- replay annotations
-- mitigation proposals
-- causal recovery paths
-
-Original events remain immutable.
-
----
-
-2. Signal before Collapse
-
-The framework focuses on detecting:
-
-- oscillation
-- divergence
-- pressure accumulation
-- replay instability
-- semantic drift
-
-before visible failure occurs.
-
-Similar to ICU monitoring:
-the goal is not to react to collapse,
-but to detect instability patterns early.
-
----
-
-3. Detection != Diagnosis
-
-A detector may identify:
-
-- instability
-- drift
-- oscillation
-- pressure spikes
-
-without knowing the root cause.
-
-The architecture explicitly separates:
-
-- observation
-- detection
-- evaluation
-- recovery
-
-to preserve causal integrity.
-
----
-
-4. Replayable Truth
-
-Every signal is:
-
-- immutable
-- replayable
-- causally anchored
-- locality-aware
-
-Historical lineage must never break.
-
-Even after decay or compression,
-minimal replay truth is preserved through shadow lineage.
-
----
-
-Architecture
-
+```text
 hospitication/
-├── core/
-│   ├── nodes/
-│   │   ├── active/
-│   │   ├── dormant/
-│   │   └── shadow/
-│   │
-│   ├── signal/
-│   │   ├── observer/
-│   │   ├── detector/
-│   │   └── emitter/
-│   │
-│   └── types.py
-│
-├── layers/
-│   ├── a_structure/
-│   ├── b_process/
-│   ├── c_stability/
-│   └── d_record/
-│
-├── analysis/
-│   ├── burden/
-│   ├── causal/
-│   └── replay/
-│
-├── recovery/
-│   ├── proposals/
-│   ├── paths/
-│   └── mitigations/
-│
-├── interface/
-│   ├── adapters/
-│   ├── contracts/
-│   └── replay_boundary/
-│
-├── db/
-└── tests/
+├── core/          # contracts, config, registry
+├── signal/        # observer, detector, emitter, envelope helpers
+├── analysis/      # structural burden analyzers
+├── recovery/      # non-mutating proposals and mitigation catalog
+├── reporter/      # deterministic markdown/json renderers
+├── docs/          # design notes and integration guidance
+└── cli.py         # command-line entrypoint
+```
 
----
+## CLI Usage
 
-Signal Doctrine
+Run a Markdown report against the current repository:
 
-Observer
+```bash
+python -m hospitication.cli --repo . --format markdown
+```
 
-Passive temporal observation.
+Write deterministic JSON:
 
-Responsibilities:
+```bash
+python -m hospitication.cli --repo . --format json --output hospitication-report.json
+```
 
-- drift accumulation
-- trend monitoring
-- continuous structural observation
+Use a concrete timestamp for replayable CI output:
 
-Observer does NOT:
+```bash
+python -m hospitication.cli --repo . --format json --timestamp 2026-05-28T00:00:00Z
+```
 
-- diagnose
-- recover
-- evaluate
+## Analyzer Coverage
 
----
+- `semantic_pressure` — overloaded W3 governance/replay vocabulary pressure.
+- `dependency_fatigue` — import breadth and repeated coupling points.
+- `replay_complexity` — event/outcome/ledger/checkpoint/replay surfaces.
+- `recovery_resistance` — large files with limited test/doc counterweight.
+- `cognitive_cost` — file count, line breadth, and configuration surface.
 
-Detector
+## W3 Integration Notes
 
-Pattern recognition layer.
+Hospitication is intentionally read-only over W3 surfaces such as:
 
-Detects:
+- `core/memory/`
+- `core/governance/`
+- `core/events/`
+- `core/runtime/`
+- `iget/`
+- `docs/`
 
-- oscillation
-- divergence
-- spike
-- drift
+It can be wired into CI or agent coordination as a health report generator. If a
+future integration writes to the W3 memory bus or outcome ledger, that integration
+should add a new derived record rather than mutate existing truth.
 
-Detector does NOT:
+## Development
 
-- determine root cause
-- recommend recovery
+Run tests:
 
----
+```bash
+python -m pytest tests/test_hospitication_core.py tests/test_hospitication_cli.py
+```
 
-Emitter
+Run syntax checks:
 
-Signal compression and emission layer.
-
-Responsibilities:
-
-- emit pressure signals
-- severity filtering
-- reduce noise
-
-Emitter does NOT:
-
-- interpret
-- mutate truth
-- recover systems
-
----
-
-Signal Lifecycle
-
-observe
-  -> detect
-      -> emit
-          -> replay
-              -> evaluate
-                  -> recover
-
-Recovery never mutates emitted truth.
-
----
-
-Pressure Grades
-
-informational_drift
-caution_pressure
-structural_instability
-critical_collapse_risk
-
-These represent structural pressure —
-not merely runtime failure severity.
-
----
-
-Replay Philosophy
-
-Replay exists to preserve:
-
-- causal lineage
-- historical integrity
-- structural memory
-
-Replay is not debugging history.
-
-Replay is:
-a preserved nervous trace of the system.
-
----
-
-Current Status
-
-Phase:
-
-- Ontology stabilization
-- Core contract locking
-- Signal doctrine definition
-
-Current implementation focus:
-
-- immutable contracts
-- replay boundaries
-- causal locality
-- signal retention philosophy
-
-Behavioral logic intentionally deferred.
-
----
-
-Design Rules
-
-MUST
-
-- Preserve historical truth
-- Separate detection from diagnosis
-- Keep signals immutable
-- Maintain replay lineage
-- Prefer locality over global noise
-
-MUST NOT
-
-- Rewrite signal history
-- Merge observer with recovery logic
-- Turn signals into logging spam
-- Mutate replay truth
-- Collapse causal boundaries
-
----
-
-Long-Term Vision
-
-Hospitication aims to become:
-
-- a structural nervous system
-- a replay-aware recovery framework
-- a causal stability layer
-- a semantic pressure monitor
-
-for complex evolving systems.
-
-Not merely a monitoring tool.
-
-Not merely observability.
-
-But a framework for preserving structural integrity under continuous change.
-
----
-
-Status
-
-Experimental architecture phase.
-
-Core ontology and contracts currently under active stabilization.
+```bash
+python -m compileall hospitication tests
+```

--- a/hospitication/__init__.py
+++ b/hospitication/__init__.py
@@ -1,0 +1,5 @@
+"""Hospitication structural health observer package."""
+
+from hospitication.core.config import VERSION
+
+__all__ = ["VERSION"]

--- a/hospitication/analysis/__init__.py
+++ b/hospitication/analysis/__init__.py
@@ -1,0 +1,1 @@
+"""Hospitication structural burden analyzers."""

--- a/hospitication/analysis/_helpers.py
+++ b/hospitication/analysis/_helpers.py
@@ -1,0 +1,33 @@
+"""Shared pure helpers for Hospitication analyzers."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from hospitication.core.config import CODE_EXTENSIONS, CONFIG_EXTENSIONS, DOC_EXTENSIONS
+from hospitication.core.types import FileObservation, ObservationSnapshot
+
+
+def clamp(value: float) -> float:
+    return round(max(0.0, min(1.0, value)), 4)
+
+
+def files_by_suffix(snapshot: ObservationSnapshot, suffixes: tuple[str, ...]) -> tuple[FileObservation, ...]:
+    return tuple(file for file in snapshot.files if file.suffix in suffixes)
+
+
+def code_files(snapshot: ObservationSnapshot) -> tuple[FileObservation, ...]:
+    return files_by_suffix(snapshot, CODE_EXTENSIONS)
+
+
+def doc_files(snapshot: ObservationSnapshot) -> tuple[FileObservation, ...]:
+    return files_by_suffix(snapshot, DOC_EXTENSIONS)
+
+
+def config_files(snapshot: ObservationSnapshot) -> tuple[FileObservation, ...]:
+    return files_by_suffix(snapshot, CONFIG_EXTENSIONS)
+
+
+def top_counts(values: list[str], limit: int = 10) -> dict[str, int]:
+    counter = Counter(values)
+    return dict(sorted(counter.most_common(limit), key=lambda item: (-item[1], item[0])))

--- a/hospitication/analysis/cognitive_cost.py
+++ b/hospitication/analysis/cognitive_cost.py
@@ -1,0 +1,25 @@
+"""Cognitive cost analyzer for repository breadth and file size distribution."""
+
+from __future__ import annotations
+
+from hospitication.analysis._helpers import clamp, config_files
+from hospitication.core.types import MetricScore, ObservationSnapshot
+
+
+def analyze_cognitive_cost(snapshot: ObservationSnapshot) -> MetricScore:
+    file_count = len(snapshot.files)
+    total_lines = snapshot.total_lines
+    configs = config_files(snapshot)
+    average_lines = total_lines / max(1, file_count)
+    score = clamp((file_count / 900.0) + (average_lines / 450.0) + (len(configs) / 250.0))
+    return MetricScore(
+        name="cognitive_cost",
+        score=score,
+        summary="Cognitive cost from file count, average size, and configuration breadth.",
+        evidence={
+            "file_count": file_count,
+            "total_lines": total_lines,
+            "average_lines_per_file": round(average_lines, 2),
+            "config_files": len(configs),
+        },
+    )

--- a/hospitication/analysis/dependency_fatigue.py
+++ b/hospitication/analysis/dependency_fatigue.py
@@ -1,0 +1,28 @@
+"""Dependency fatigue analyzer for import breadth and dependency concentration."""
+
+from __future__ import annotations
+
+from hospitication.analysis._helpers import clamp, code_files, top_counts
+from hospitication.core.types import MetricScore, ObservationSnapshot
+
+
+def analyze_dependency_fatigue(snapshot: ObservationSnapshot) -> MetricScore:
+    code = code_files(snapshot)
+    imports: list[str] = []
+    for file in code:
+        imports.extend(file.imports)
+    unique_imports = set(imports)
+    breadth = len(unique_imports) / max(1, len(code))
+    concentration = max(top_counts(imports, limit=1).values(), default=0) / max(1, len(imports))
+    score = clamp((breadth / 8.0) + (concentration * 0.25))
+    return MetricScore(
+        name="dependency_fatigue",
+        score=score,
+        summary="Dependency fatigue from import breadth and repeated coupling points.",
+        evidence={
+            "code_files": len(code),
+            "unique_imports": len(unique_imports),
+            "import_mentions": len(imports),
+            "top_imports": top_counts(imports, limit=8),
+        },
+    )

--- a/hospitication/analysis/recovery_resistance.py
+++ b/hospitication/analysis/recovery_resistance.py
@@ -1,0 +1,30 @@
+"""Recovery resistance analyzer for large files and sparse tests/docs counterweight."""
+
+from __future__ import annotations
+
+from hospitication.analysis._helpers import clamp, code_files, doc_files
+from hospitication.core.types import MetricScore, ObservationSnapshot
+
+
+def analyze_recovery_resistance(snapshot: ObservationSnapshot) -> MetricScore:
+    code = code_files(snapshot)
+    docs = doc_files(snapshot)
+    test_files = tuple(file for file in snapshot.files if "test" in file.path.lower())
+    large_files = tuple(file for file in snapshot.files if file.line_count >= 300)
+    test_ratio = len(test_files) / max(1, len(code))
+    doc_ratio = len(docs) / max(1, len(code))
+    large_pressure = len(large_files) / max(1, len(snapshot.files))
+    missing_counterweight = max(0.0, 0.6 - min(0.6, test_ratio + doc_ratio * 0.5))
+    score = clamp(large_pressure * 2.0 + missing_counterweight)
+    return MetricScore(
+        name="recovery_resistance",
+        score=score,
+        summary="Recovery resistance from large surfaces with limited tests/docs counterweight.",
+        evidence={
+            "large_files": tuple(file.path for file in sorted(large_files, key=lambda item: (-item.line_count, item.path))[:10]),
+            "large_file_count": len(large_files),
+            "test_files": len(test_files),
+            "doc_files": len(docs),
+            "code_files": len(code),
+        },
+    )

--- a/hospitication/analysis/replay_complexity.py
+++ b/hospitication/analysis/replay_complexity.py
@@ -1,0 +1,30 @@
+"""Replay complexity analyzer for event, outcome, ledger, and replay surfaces."""
+
+from __future__ import annotations
+
+from hospitication.analysis._helpers import clamp
+from hospitication.core.types import MetricScore, ObservationSnapshot
+
+REPLAY_TERMS = ("replay", "outcome", "ledger", "event", "trace", "checkpoint", "rollback")
+
+
+def analyze_replay_complexity(snapshot: ObservationSnapshot) -> MetricScore:
+    paths = [file.path for file in snapshot.files]
+    replay_paths = [path for path in paths if any(term in path.lower() for term in REPLAY_TERMS)]
+    marker_hits = sum(
+        1
+        for file in snapshot.files
+        for marker in file.markers
+        if marker.lower() in REPLAY_TERMS
+    )
+    score = clamp((len(replay_paths) / max(1, len(snapshot.files))) * 3.0 + marker_hits / 60.0)
+    return MetricScore(
+        name="replay_complexity",
+        score=score,
+        summary="Replay complexity from event/outcome/ledger/checkpoint surfaces.",
+        evidence={
+            "replay_related_files": tuple(sorted(replay_paths)[:20]),
+            "replay_related_file_count": len(replay_paths),
+            "replay_marker_hits": marker_hits,
+        },
+    )

--- a/hospitication/analysis/semantic_pressure.py
+++ b/hospitication/analysis/semantic_pressure.py
@@ -1,0 +1,38 @@
+"""Semantic pressure analyzer for overloaded concepts and governance terms."""
+
+from __future__ import annotations
+
+from hospitication.analysis._helpers import clamp, doc_files, top_counts
+from hospitication.core.types import MetricScore, ObservationSnapshot
+
+SEMANTIC_TERMS = (
+    "truth",
+    "governance",
+    "memory",
+    "replay",
+    "signal",
+    "recovery",
+    "protocol",
+    "mpcp",
+    "outcome",
+    "ledger",
+)
+
+
+def analyze_semantic_pressure(snapshot: ObservationSnapshot) -> MetricScore:
+    docs = doc_files(snapshot)
+    marker_hits: list[str] = []
+    for file in snapshot.files:
+        marker_hits.extend(marker.lower() for marker in file.markers if marker.lower() in SEMANTIC_TERMS)
+    density = len(marker_hits) / max(1, len(docs) + len(snapshot.files) * 0.15)
+    score = clamp(density / 5.0)
+    return MetricScore(
+        name="semantic_pressure",
+        score=score,
+        summary="Semantic pressure from repeated W3 governance/replay concepts.",
+        evidence={
+            "semantic_marker_hits": len(marker_hits),
+            "top_terms": top_counts(marker_hits, limit=8),
+            "doc_files": len(docs),
+        },
+    )

--- a/hospitication/cli.py
+++ b/hospitication/cli.py
@@ -1,0 +1,92 @@
+"""Command-line entrypoint for Hospitication."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from hospitication.core.config import HospiticationConfig
+from hospitication.core.registry import default_registry
+from hospitication.core.types import HealthReport
+from hospitication.recovery.proposals import propose_recovery
+from hospitication.reporter.json_report import render_json
+from hospitication.reporter.markdown import render_markdown
+from hospitication.signal.detector import detect_signals
+from hospitication.signal.emitter import emit_signals
+from hospitication.signal.observer import observe_repository
+
+
+def build_report(repo_root: str | Path, config: HospiticationConfig | None = None) -> HealthReport:
+    cfg = config or HospiticationConfig()
+    snapshot = observe_repository(repo_root, cfg)
+    registry = default_registry()
+    metrics = tuple(analyzer(snapshot) for analyzer in registry.analyzers())
+    detections = detect_signals(metrics)
+    signals = emit_signals(detections, cfg)
+    proposals = propose_recovery(metrics, signals)
+    summary = _summary(metrics, signals, proposals)
+    return HealthReport(
+        generated_at=cfg.deterministic_timestamp,
+        repo_root=snapshot.repo_root,
+        metrics=metrics,
+        signals=signals,
+        proposals=proposals,
+        summary=summary,
+    )
+
+
+def render_report(report: HealthReport, output_format: str) -> str:
+    if output_format == "json":
+        return render_json(report)
+    if output_format == "markdown":
+        return render_markdown(report)
+    raise ValueError(f"Unsupported report format: {output_format}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="hospitication",
+        description="Observe W3 structural health and propose non-mutating recovery.",
+    )
+    parser.add_argument("--repo", default=".", help="Repository root to observe")
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Report format",
+    )
+    parser.add_argument("--output", help="Optional output file. Defaults to stdout.")
+    parser.add_argument(
+        "--timestamp",
+        default=None,
+        help="Deterministic report timestamp. Defaults to config timestamp.",
+    )
+    args = parser.parse_args(argv)
+
+    config = HospiticationConfig(
+        deterministic_timestamp=args.timestamp or HospiticationConfig().deterministic_timestamp
+    )
+    report = build_report(args.repo, config)
+    rendered = render_report(report, args.format)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+def _summary(metrics, signals, proposals) -> str:
+    if not metrics:
+        return "No metrics produced."
+    highest = max(metrics, key=lambda metric: (metric.score, metric.name))
+    return (
+        f"Highest pressure: {highest.name}={highest.score:.4f}; "
+        f"signals={len(signals)}; proposals={len(proposals)}."
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hospitication/core/__init__.py
+++ b/hospitication/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core Hospitication contracts and configuration."""

--- a/hospitication/core/config.py
+++ b/hospitication/core/config.py
@@ -1,0 +1,53 @@
+"""Configuration for Hospitication read-only observation and reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+VERSION = "0.1.0"
+DEFAULT_TIMESTAMP = "1970-01-01T00:00:00Z"
+
+CODE_EXTENSIONS = (
+    ".py",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".go",
+    ".java",
+    ".rs",
+    ".rb",
+    ".php",
+    ".c",
+    ".cpp",
+    ".h",
+    ".sh",
+)
+DOC_EXTENSIONS = (".md", ".txt", ".rst", ".adoc")
+CONFIG_EXTENSIONS = (".json", ".yml", ".yaml", ".toml", ".ini", ".cfg")
+DEFAULT_IGNORED_DIRS = (
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".pytest_cache",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+)
+DEFAULT_MAX_FILE_BYTES = 1_000_000
+
+
+@dataclass(frozen=True)
+class HospiticationConfig:
+    """Read-only configuration for an observation run."""
+
+    ignored_dirs: tuple[str, ...] = DEFAULT_IGNORED_DIRS
+    code_extensions: tuple[str, ...] = CODE_EXTENSIONS
+    doc_extensions: tuple[str, ...] = DOC_EXTENSIONS
+    config_extensions: tuple[str, ...] = CONFIG_EXTENSIONS
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
+    deterministic_timestamp: str = DEFAULT_TIMESTAMP
+    emit_threshold: float = 0.2

--- a/hospitication/core/registry.py
+++ b/hospitication/core/registry.py
@@ -1,0 +1,43 @@
+"""Analyzer registry used by CLI and production orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from hospitication.core.types import MetricScore, ObservationSnapshot
+
+Analyzer = Callable[[ObservationSnapshot], MetricScore]
+
+
+class AnalyzerRegistry:
+    """Small deterministic registry; avoids dynamic imports and hidden mutation."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, Analyzer] = {}
+
+    def register(self, name: str, analyzer: Analyzer) -> None:
+        if not name:
+            raise ValueError("Analyzer name is required")
+        self._items[name] = analyzer
+
+    def analyzers(self) -> tuple[Analyzer, ...]:
+        return tuple(self._items[name] for name in sorted(self._items))
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._items))
+
+
+def default_registry() -> AnalyzerRegistry:
+    from hospitication.analysis.cognitive_cost import analyze_cognitive_cost
+    from hospitication.analysis.dependency_fatigue import analyze_dependency_fatigue
+    from hospitication.analysis.recovery_resistance import analyze_recovery_resistance
+    from hospitication.analysis.replay_complexity import analyze_replay_complexity
+    from hospitication.analysis.semantic_pressure import analyze_semantic_pressure
+
+    registry = AnalyzerRegistry()
+    registry.register("cognitive_cost", analyze_cognitive_cost)
+    registry.register("dependency_fatigue", analyze_dependency_fatigue)
+    registry.register("recovery_resistance", analyze_recovery_resistance)
+    registry.register("replay_complexity", analyze_replay_complexity)
+    registry.register("semantic_pressure", analyze_semantic_pressure)
+    return registry

--- a/hospitication/core/types.py
+++ b/hospitication/core/types.py
@@ -1,15 +1,15 @@
 # ==========================================
 # Hospitication — Core Type Contracts
-# Data structures only — no logic
+# Data structures only — no orchestration logic
 # ==========================================
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal, Mapping
 
 # ── Hard limits ────────────────────────────────────────────────
-GRID_SIZE        = 16        # 16x16 = 256 nodes max
+GRID_SIZE = 16  # 16x16 = 256 nodes max
 MAX_SIGNAL_DEPTH = 5
 
 # ── Node states ────────────────────────────────────────────────
@@ -29,9 +29,15 @@ PersistenceScope = Literal["permanent", "session", "ephemeral"]
 
 # ── Detector types ─────────────────────────────────────────────
 DetectorType = Literal["oscillation", "divergence", "spike", "drift"]
+AnalyzerName = Literal[
+    "semantic_pressure",
+    "dependency_fatigue",
+    "replay_complexity",
+    "recovery_resistance",
+    "cognitive_cost",
+]
+ProposalStatus = Literal["proposed"]
 
-
-# ── NodeRef ────────────────────────────────────────────────────
 
 @dataclass(frozen=True)
 class NodeRef:
@@ -40,15 +46,81 @@ class NodeRef:
     Signal locality — every signal anchors to a node.
     Immutable by design.
     """
-    x: int   # 0-15
-    y: int   # 0-15
 
-    def __post_init__(self):
-        assert 0 <= self.x < GRID_SIZE
-        assert 0 <= self.y < GRID_SIZE
+    x: int  # 0-15
+    y: int  # 0-15
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.x < GRID_SIZE:
+            raise ValueError(f"NodeRef.x must be in 0..{GRID_SIZE - 1}: {self.x}")
+        if not 0 <= self.y < GRID_SIZE:
+            raise ValueError(f"NodeRef.y must be in 0..{GRID_SIZE - 1}: {self.y}")
 
 
-# ── SignalEnvelope ─────────────────────────────────────────────
+@dataclass(frozen=True)
+class FileObservation:
+    """Read-only structural observation for one repository file."""
+
+    path: str
+    suffix: str
+    line_count: int
+    byte_count: int
+    imports: tuple[str, ...] = ()
+    markers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ObservationSnapshot:
+    """Immutable repository snapshot used by analyzers and detectors."""
+
+    repo_root: str
+    files: tuple[FileObservation, ...]
+    observed_at: str
+    ignored_dirs: tuple[str, ...] = ()
+
+    @property
+    def total_lines(self) -> int:
+        return sum(file.line_count for file in self.files)
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(file.byte_count for file in self.files)
+
+
+@dataclass(frozen=True)
+class MetricScore:
+    """Analyzer output. A score is pressure evidence, not a recovery action."""
+
+    name: AnalyzerName
+    score: float
+    summary: str
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.score <= 1.0:
+            raise ValueError(f"MetricScore.score must be 0.0..1.0: {self.score}")
+
+
+@dataclass(frozen=True)
+class DetectorResult:
+    """
+    What the detector found — NOT a diagnosis.
+
+    "detected" is not "root cause known". Detection must not recommend recovery.
+    """
+
+    detector_type: DetectorType
+    detected: bool
+    confidence: float  # 0.0 - 1.0
+    locality: NodeRef
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                f"DetectorResult.confidence must be 0.0..1.0: {self.confidence}"
+            )
+
 
 @dataclass(frozen=True)
 class SignalEnvelope:
@@ -60,50 +132,62 @@ class SignalEnvelope:
     signal ≠ logging
     signal = structural nervous response
     """
-    signal_id:    str
-    timestamp:    float
-    origin_node:  NodeRef
 
+    signal_id: str
+    timestamp: str
+    origin_node: NodeRef
     detector_type: DetectorType
-    pressure:      PressureGrade
+    pressure: PressureGrade
+    confidence: float
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    retention: RetentionPolicy = "standard"
+    persistence: PersistenceScope = "session"
+    parent_id: str | None = None
+    is_derived: bool = False
 
-    # Retention
-    retention:     RetentionPolicy  = "standard"
-    persistence:   PersistenceScope = "session"
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                f"SignalEnvelope.confidence must be 0.0..1.0: {self.confidence}"
+            )
 
-    # Lineage — link to parent signal if derived
-    parent_id:    str | None = None
-    is_derived:   bool       = False
-
-    def to_shadow(self) -> dict:
+    def to_shadow(self) -> dict[str, Any]:
         """Minimal lineage — always retained even after decay."""
         return {
-            "signal_id":  self.signal_id,
-            "timestamp":  self.timestamp,
+            "signal_id": self.signal_id,
+            "timestamp": self.timestamp,
             "origin_node": (self.origin_node.x, self.origin_node.y),
-            "retention":  self.retention,
+            "retention": self.retention,
         }
 
 
-# ── DetectorResult ─────────────────────────────────────────────
+@dataclass(frozen=True)
+class RecoveryProposal:
+    """Non-mutating recovery proposal. This is never an applied change."""
 
-@dataclass
-class DetectorResult:
-    """
-    What the detector found — NOT a diagnosis.
+    proposal_id: str
+    title: str
+    rationale: str
+    target_paths: tuple[str, ...] = ()
+    actions: tuple[str, ...] = ()
+    source_metrics: tuple[AnalyzerName, ...] = ()
+    status: ProposalStatus = "proposed"
+    destructive: bool = False
 
-    "detected" ≠ "root cause known"
-    System can detect before it understands.
-    """
-    detector_type: DetectorType
-    detected:      bool
-    confidence:    float        # 0.0 - 1.0
-    locality:      NodeRef
-    evidence:      dict         # raw observation data, no interpretation
 
-    # Explicitly not included:
-    # - cause
-    # - recommendation
-    # - recovery path
-    # Those belong to evaluation and recovery layers.
+@dataclass(frozen=True)
+class HealthReport:
+    """Complete deterministic Hospitication report payload."""
 
+    generated_at: str
+    repo_root: str
+    metrics: tuple[MetricScore, ...]
+    signals: tuple[SignalEnvelope, ...]
+    proposals: tuple[RecoveryProposal, ...]
+    summary: str
+
+    @property
+    def overall_score(self) -> float:
+        if not self.metrics:
+            return 0.0
+        return round(sum(metric.score for metric in self.metrics) / len(self.metrics), 4)

--- a/hospitication/docs/ARCHITECTURE.md
+++ b/hospitication/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Hospitication Architecture
+
+Hospitication models repository health as structural pressure, not simple style
+violations. The architecture is intentionally layered to preserve W3 governance
+and replay boundaries.
+
+## Layer Responsibilities
+
+| Layer | May Do | Must Not Do |
+| --- | --- | --- |
+| Observer | Read files and build immutable snapshots | Diagnose, recover, or write files |
+| Analyzer | Compute burden metrics | Emit signals or apply recovery |
+| Detector | Detect drift/spike/oscillation/divergence | Recommend recovery or diagnose root cause |
+| Emitter | Create immutable signal envelopes | Interpret or mutate truth |
+| Recovery | Produce proposals | Apply destructive changes |
+| Reporter | Render Markdown/JSON | Change process or repository state |
+
+## Determinism
+
+Reports sort metrics, signals, and proposals. The default timestamp is fixed so
+CI output is replayable; callers may pass an explicit timestamp when needed.
+
+## Recovery Doctrine
+
+Recovery is proposal-first. A proposal is a new derived artifact and never a
+mutation of the underlying observation, detection, signal, memory, or ledger
+truth.

--- a/hospitication/docs/CLI.md
+++ b/hospitication/docs/CLI.md
@@ -1,0 +1,16 @@
+# Hospitication CLI
+
+```bash
+python -m hospitication.cli --repo . --format markdown
+python -m hospitication.cli --repo . --format json --output report.json
+```
+
+Options:
+
+- `--repo`: repository root to observe.
+- `--format`: `markdown` or `json`.
+- `--output`: optional output path.
+- `--timestamp`: explicit deterministic timestamp for replayable reports.
+
+The CLI does not perform destructive actions. Writing `--output` only writes the
+rendered report to the requested path.

--- a/hospitication/recovery/__init__.py
+++ b/hospitication/recovery/__init__.py
@@ -1,0 +1,1 @@
+"""Non-mutating Hospitication recovery proposals."""

--- a/hospitication/recovery/mitigations.py
+++ b/hospitication/recovery/mitigations.py
@@ -1,0 +1,26 @@
+"""Mitigation text catalog. Text only; no filesystem mutation."""
+
+from __future__ import annotations
+
+MITIGATIONS = {
+    "semantic_pressure": (
+        "Create or refresh a compact glossary for overloaded W3 terms.",
+        "Add causal anchors when a document introduces new governance/replay meaning.",
+    ),
+    "dependency_fatigue": (
+        "Review high-frequency imports and document intended dependency boundaries.",
+        "Prefer boundary modules over direct cross-layer imports when pressure rises.",
+    ),
+    "replay_complexity": (
+        "Keep replay, event, and outcome-ledger contracts explicitly versioned.",
+        "Add replay fixtures before changing recovery or ledger behavior.",
+    ),
+    "recovery_resistance": (
+        "Split large change surfaces with tests before attempting recovery work.",
+        "Prefer proposal-first recovery plans and avoid direct truth mutation.",
+    ),
+    "cognitive_cost": (
+        "Add index documents for high-breadth areas and remove stale navigation paths.",
+        "Group operational docs by owner, lifecycle, and replay relevance.",
+    ),
+}

--- a/hospitication/recovery/proposals.py
+++ b/hospitication/recovery/proposals.py
@@ -1,0 +1,62 @@
+"""Recovery proposal layer. It only proposes; it never applies changes."""
+
+from __future__ import annotations
+
+import hashlib
+
+from hospitication.core.types import AnalyzerName, MetricScore, RecoveryProposal, SignalEnvelope
+from hospitication.recovery.mitigations import MITIGATIONS
+
+
+def propose_recovery(
+    metrics: tuple[MetricScore, ...],
+    signals: tuple[SignalEnvelope, ...] = (),
+) -> tuple[RecoveryProposal, ...]:
+    proposals: list[RecoveryProposal] = []
+    pressure_metrics = tuple(sorted((m for m in metrics if m.score >= 0.35), key=lambda item: item.name))
+    for metric in pressure_metrics:
+        actions = MITIGATIONS.get(metric.name, ("Review this pressure metric before recovery.",))
+        target_paths = _target_paths(metric)
+        proposals.append(
+            RecoveryProposal(
+                proposal_id=_proposal_id(metric.name, metric.score, target_paths),
+                title=f"Mitigate {metric.name.replace('_', ' ')}",
+                rationale=f"Metric score {metric.score:.4f}: {metric.summary}",
+                target_paths=target_paths,
+                actions=tuple(actions),
+                source_metrics=(metric.name,),
+                destructive=False,
+            )
+        )
+
+    if signals and len(signals) >= 4:
+        proposals.append(
+            RecoveryProposal(
+                proposal_id=_proposal_id("signal_review", float(len(signals)), ()),
+                title="Review clustered signal pressure",
+                rationale=f"{len(signals)} emitted signals indicate structural pressure clustering.",
+                actions=(
+                    "Review signal evidence in descending confidence order.",
+                    "Attach recovery notes as new annotations, not mutations of emitted truth.",
+                ),
+                source_metrics=tuple(metric.name for metric in pressure_metrics),
+                destructive=False,
+            )
+        )
+    return tuple(proposals)
+
+
+def _target_paths(metric: MetricScore) -> tuple[str, ...]:
+    evidence = metric.evidence
+    for key in ("large_files", "replay_related_files"):
+        values = evidence.get(key)
+        if isinstance(values, tuple):
+            return tuple(str(value) for value in values[:5])
+        if isinstance(values, list):
+            return tuple(str(value) for value in values[:5])
+    return ()
+
+
+def _proposal_id(name: AnalyzerName | str, score: float, paths: tuple[str, ...]) -> str:
+    seed = f"{name}|{score:.4f}|{repr(paths)}"
+    return "prop_" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]

--- a/hospitication/reporter/__init__.py
+++ b/hospitication/reporter/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic Hospitication report renderers."""

--- a/hospitication/reporter/json_report.py
+++ b/hospitication/reporter/json_report.py
@@ -1,0 +1,26 @@
+"""Deterministic JSON report rendering."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any
+
+from hospitication.core.types import HealthReport
+from hospitication.signal.envelopes import signal_to_dict
+
+
+def report_to_dict(report: HealthReport) -> dict[str, Any]:
+    return {
+        "generated_at": report.generated_at,
+        "repo_root": report.repo_root,
+        "summary": report.summary,
+        "overall_score": report.overall_score,
+        "metrics": [asdict(metric) for metric in sorted(report.metrics, key=lambda item: item.name)],
+        "signals": [signal_to_dict(signal) for signal in sorted(report.signals, key=lambda item: item.signal_id)],
+        "proposals": [asdict(proposal) for proposal in sorted(report.proposals, key=lambda item: item.proposal_id)],
+    }
+
+
+def render_json(report: HealthReport) -> str:
+    return json.dumps(report_to_dict(report), ensure_ascii=False, indent=2, sort_keys=True) + "\n"

--- a/hospitication/reporter/markdown.py
+++ b/hospitication/reporter/markdown.py
@@ -1,0 +1,63 @@
+"""Deterministic markdown report rendering."""
+
+from __future__ import annotations
+
+from hospitication.core.types import HealthReport
+
+
+def render_markdown(report: HealthReport) -> str:
+    lines: list[str] = [
+        "# Hospitication Health Report",
+        "",
+        f"- Generated at: `{report.generated_at}`",
+        f"- Repository: `{report.repo_root}`",
+        f"- Overall pressure score: `{report.overall_score:.4f}`",
+        f"- Summary: {report.summary}",
+        "",
+        "## Metrics",
+        "",
+        "| Metric | Score | Summary |",
+        "| --- | ---: | --- |",
+    ]
+    for metric in sorted(report.metrics, key=lambda item: item.name):
+        lines.append(f"| `{metric.name}` | `{metric.score:.4f}` | {metric.summary} |")
+
+    lines.extend(["", "## Signals", ""])
+    if report.signals:
+        lines.append("| Signal | Type | Pressure | Confidence | Node |")
+        lines.append("| --- | --- | --- | ---: | --- |")
+        for signal in sorted(report.signals, key=lambda item: item.signal_id):
+            node = f"({signal.origin_node.x},{signal.origin_node.y})"
+            lines.append(
+                f"| `{signal.signal_id}` | `{signal.detector_type}` | `{signal.pressure}` | "
+                f"`{signal.confidence:.4f}` | `{node}` |"
+            )
+    else:
+        lines.append("No signals emitted above threshold.")
+
+    lines.extend(["", "## Recovery Proposals", ""])
+    if report.proposals:
+        for proposal in sorted(report.proposals, key=lambda item: item.proposal_id):
+            lines.extend(
+                [
+                    f"### {proposal.title}",
+                    "",
+                    f"- ID: `{proposal.proposal_id}`",
+                    f"- Status: `{proposal.status}`",
+                    f"- Destructive: `{proposal.destructive}`",
+                    f"- Rationale: {proposal.rationale}",
+                    "- Actions:",
+                ]
+            )
+            for action in proposal.actions:
+                lines.append(f"  - {action}")
+            if proposal.target_paths:
+                lines.append("- Target paths:")
+                for path in proposal.target_paths:
+                    lines.append(f"  - `{path}`")
+            lines.append("")
+    else:
+        lines.append("No recovery proposals required. Recovery layer did not mutate truth.")
+
+    lines.append("_Hospitication observes, detects, emits, evaluates, and proposes; it does not mutate truth._")
+    return "\n".join(lines).rstrip() + "\n"

--- a/hospitication/signal/__init__.py
+++ b/hospitication/signal/__init__.py
@@ -1,0 +1,1 @@
+"""Observe, detect, and emit Hospitication signals."""

--- a/hospitication/signal/detector.py
+++ b/hospitication/signal/detector.py
@@ -1,0 +1,79 @@
+"""Pattern detectors for Hospitication signals.
+
+Detectors only detect drift/spike/oscillation/divergence. They never diagnose,
+recommend, or mutate truth.
+"""
+
+from __future__ import annotations
+
+from hospitication.core.types import DetectorResult, MetricScore, NodeRef
+
+
+def detect_signals(metrics: tuple[MetricScore, ...]) -> tuple[DetectorResult, ...]:
+    ordered = tuple(sorted(metrics, key=lambda item: item.name))
+    results: list[DetectorResult] = []
+    scores = [metric.score for metric in ordered]
+
+    for index, metric in enumerate(ordered):
+        node = NodeRef(index % 16, index // 16)
+        if metric.score >= 0.65:
+            results.append(
+                DetectorResult(
+                    detector_type="spike",
+                    detected=True,
+                    confidence=round(metric.score, 4),
+                    locality=node,
+                    evidence={"metric": metric.name, "score": metric.score},
+                )
+            )
+        elif metric.score >= 0.2:
+            results.append(
+                DetectorResult(
+                    detector_type="drift",
+                    detected=True,
+                    confidence=round(metric.score, 4),
+                    locality=node,
+                    evidence={"metric": metric.name, "score": metric.score},
+                )
+            )
+
+    if scores:
+        spread = max(scores) - min(scores)
+        if spread >= 0.45:
+            results.append(
+                DetectorResult(
+                    detector_type="divergence",
+                    detected=True,
+                    confidence=round(spread, 4),
+                    locality=NodeRef(15, 15),
+                    evidence={"score_spread": round(spread, 4)},
+                )
+            )
+
+    oscillation = _oscillation_score(scores)
+    if oscillation >= 0.5:
+        results.append(
+            DetectorResult(
+                detector_type="oscillation",
+                detected=True,
+                confidence=round(oscillation, 4),
+                locality=NodeRef(14, 15),
+                evidence={"direction_changes": oscillation},
+            )
+        )
+
+    return tuple(results)
+
+
+def _oscillation_score(scores: list[float]) -> float:
+    if len(scores) < 3:
+        return 0.0
+    changes = 0
+    previous_direction = 0
+    for left, right in zip(scores, scores[1:]):
+        direction = 1 if right > left else -1 if right < left else 0
+        if direction and previous_direction and direction != previous_direction:
+            changes += 1
+        if direction:
+            previous_direction = direction
+    return min(1.0, changes / max(1, len(scores) - 2))

--- a/hospitication/signal/emitter.py
+++ b/hospitication/signal/emitter.py
@@ -1,0 +1,62 @@
+"""Signal emitter. Emits immutable envelopes; does not interpret or recover."""
+
+from __future__ import annotations
+
+import hashlib
+
+from hospitication.core.config import DEFAULT_TIMESTAMP, HospiticationConfig
+from hospitication.core.types import DetectorResult, PressureGrade, SignalEnvelope
+
+
+def pressure_for_confidence(confidence: float) -> PressureGrade:
+    if confidence >= 0.85:
+        return "critical_collapse_risk"
+    if confidence >= 0.65:
+        return "structural_instability"
+    if confidence >= 0.35:
+        return "caution_pressure"
+    return "informational_drift"
+
+
+def emit_signals(
+    detections: tuple[DetectorResult, ...],
+    config: HospiticationConfig | None = None,
+) -> tuple[SignalEnvelope, ...]:
+    cfg = config or HospiticationConfig()
+    emitted: list[SignalEnvelope] = []
+    for detection in sorted(
+        detections,
+        key=lambda item: (item.detector_type, item.locality.x, item.locality.y, repr(item.evidence)),
+    ):
+        if not detection.detected or detection.confidence < cfg.emit_threshold:
+            continue
+        signal_id = _stable_signal_id(detection, cfg.deterministic_timestamp)
+        pressure = pressure_for_confidence(detection.confidence)
+        emitted.append(
+            SignalEnvelope(
+                signal_id=signal_id,
+                timestamp=cfg.deterministic_timestamp or DEFAULT_TIMESTAMP,
+                origin_node=detection.locality,
+                detector_type=detection.detector_type,
+                pressure=pressure,
+                confidence=detection.confidence,
+                evidence=dict(sorted(detection.evidence.items())),
+                retention="critical" if pressure == "critical_collapse_risk" else "standard",
+                persistence="permanent" if pressure == "critical_collapse_risk" else "session",
+            )
+        )
+    return tuple(emitted)
+
+
+def _stable_signal_id(detection: DetectorResult, timestamp: str) -> str:
+    seed = "|".join(
+        [
+            timestamp,
+            detection.detector_type,
+            str(detection.locality.x),
+            str(detection.locality.y),
+            f"{detection.confidence:.4f}",
+            repr(sorted(detection.evidence.items())),
+        ]
+    )
+    return "sig_" + hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]

--- a/hospitication/signal/envelopes.py
+++ b/hospitication/signal/envelopes.py
@@ -1,0 +1,17 @@
+"""Signal envelope helpers kept separate from detection/recovery logic."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from hospitication.core.types import SignalEnvelope
+
+
+def signal_to_dict(signal: SignalEnvelope) -> dict[str, Any]:
+    payload = asdict(signal)
+    payload["origin_node"] = {
+        "x": signal.origin_node.x,
+        "y": signal.origin_node.y,
+    }
+    return payload

--- a/hospitication/signal/observer.py
+++ b/hospitication/signal/observer.py
@@ -1,0 +1,85 @@
+"""Read-only repository observer for Hospitication."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from hospitication.core.config import HospiticationConfig
+from hospitication.core.types import FileObservation, ObservationSnapshot
+
+MARKER_WORDS = (
+    "TODO",
+    "FIXME",
+    "HACK",
+    "XXX",
+    "deprecated",
+    "rollback",
+    "replay",
+    "governance",
+    "memory",
+    "mpcp",
+)
+
+
+def observe_repository(
+    repo_root: str | Path,
+    config: HospiticationConfig | None = None,
+) -> ObservationSnapshot:
+    """Return an immutable structural snapshot without mutating the repository."""
+
+    cfg = config or HospiticationConfig()
+    root = Path(repo_root).resolve()
+    observations: list[FileObservation] = []
+
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        relative_parts = path.relative_to(root).parts
+        if any(part in cfg.ignored_dirs for part in relative_parts):
+            continue
+        if path.stat().st_size > cfg.max_file_bytes:
+            continue
+        observations.append(_observe_file(root, path, cfg))
+
+    return ObservationSnapshot(
+        repo_root=str(root),
+        files=tuple(observations),
+        observed_at=cfg.deterministic_timestamp,
+        ignored_dirs=tuple(sorted(cfg.ignored_dirs)),
+    )
+
+
+def _observe_file(
+    root: Path,
+    path: Path,
+    config: HospiticationConfig,
+) -> FileObservation:
+    raw = path.read_bytes()
+    text = raw.decode("utf-8", errors="ignore")
+    suffix = path.suffix.lower()
+    imports: tuple[str, ...] = ()
+    if suffix == ".py":
+        imports = _python_imports(text)
+
+    markers = tuple(sorted(marker for marker in MARKER_WORDS if marker.lower() in text.lower()))
+    return FileObservation(
+        path=path.relative_to(root).as_posix(),
+        suffix=suffix,
+        line_count=len(text.splitlines()),
+        byte_count=len(raw),
+        imports=imports,
+        markers=markers,
+    )
+
+
+def _python_imports(text: str) -> tuple[str, ...]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return ()
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".")[0])
+    return tuple(sorted(imports))

--- a/tests/test_hospitication_cli.py
+++ b/tests/test_hospitication_cli.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def test_cli_json_stdout(tmp_path):
+    (tmp_path / "README.md").write_text("memory replay governance signal recovery\n", encoding="utf-8")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hospitication.cli",
+            "--repo",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--timestamp",
+            "2026-05-28T00:00:00Z",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(completed.stdout)
+    assert payload["generated_at"] == "2026-05-28T00:00:00Z"
+    assert payload["metrics"]
+    assert payload["repo_root"] == str(tmp_path.resolve())
+
+
+def test_cli_output_file(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "module.py").write_text("import json\n", encoding="utf-8")
+    output = tmp_path / "report.md"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hospitication.cli",
+            "--repo",
+            str(repo),
+            "--format",
+            "markdown",
+            "--output",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert output.exists()
+    assert output.read_text(encoding="utf-8").startswith("# Hospitication Health Report")

--- a/tests/test_hospitication_core.py
+++ b/tests/test_hospitication_core.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from hospitication.core.config import HospiticationConfig
+from hospitication.core.types import NodeRef, SignalEnvelope
+from hospitication.recovery.proposals import propose_recovery
+from hospitication.reporter.json_report import render_json
+from hospitication.reporter.markdown import render_markdown
+from hospitication.signal.detector import detect_signals
+from hospitication.signal.emitter import emit_signals
+from hospitication.signal.observer import observe_repository
+from hospitication.cli import build_report
+
+
+def make_repo(tmp_path):
+    (tmp_path / "core" / "memory").mkdir(parents=True)
+    (tmp_path / "core" / "governance").mkdir(parents=True)
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "core" / "memory" / "memory_bus.py").write_text(
+        "import json\nimport pathlib\n# replay governance memory signal\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "core" / "governance" / "README.md").write_text(
+        "governance replay recovery signal truth mpcp\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "tests" / "test_memory.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_observer_is_read_only_and_deterministic(tmp_path):
+    repo = make_repo(tmp_path)
+    before = sorted(path.relative_to(repo).as_posix() for path in repo.rglob("*") if path.is_file())
+
+    first = observe_repository(repo)
+    second = observe_repository(repo)
+
+    after = sorted(path.relative_to(repo).as_posix() for path in repo.rglob("*") if path.is_file())
+    assert before == after
+    assert first == second
+    assert tuple(file.path for file in first.files) == tuple(sorted(file.path for file in first.files))
+
+
+def test_signal_envelope_and_node_are_immutable():
+    envelope = SignalEnvelope(
+        signal_id="sig_test",
+        timestamp="1970-01-01T00:00:00Z",
+        origin_node=NodeRef(1, 2),
+        detector_type="drift",
+        pressure="informational_drift",
+        confidence=0.25,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        envelope.signal_id = "sig_mutated"
+
+    assert envelope.to_shadow()["origin_node"] == (1, 2)
+
+
+def test_report_pipeline_emits_deterministic_json_and_markdown(tmp_path):
+    repo = make_repo(tmp_path)
+    config = HospiticationConfig(deterministic_timestamp="2026-05-28T00:00:00Z")
+
+    first = build_report(repo, config)
+    second = build_report(repo, config)
+
+    assert render_json(first) == render_json(second)
+    markdown = render_markdown(first)
+    assert "# Hospitication Health Report" in markdown
+    assert "Recovery Proposals" in markdown
+    assert first.generated_at == second.generated_at == "2026-05-28T00:00:00Z"
+
+
+def test_detector_and_recovery_boundaries_do_not_diagnose_or_mutate(tmp_path):
+    repo = make_repo(tmp_path)
+    report = build_report(repo)
+    detections = detect_signals(report.metrics)
+    signals = emit_signals(detections)
+    proposals = propose_recovery(report.metrics, signals)
+
+    for detection in detections:
+        assert "recommendation" not in detection.evidence
+        assert "cause" not in detection.evidence
+
+    for proposal in proposals:
+        assert proposal.status == "proposed"
+        assert proposal.destructive is False


### PR DESCRIPTION
### Motivation
- Introduce a read-only Structural Recovery & Signal Stability framework that observes W3 repositories, emits immutable signals, and proposes non-mutating recoveries while preserving historical truth. 
- Provide deterministic, CI-friendly reports and strict separation between observation, detection, evaluation, emission, recovery (proposal-only), and reporting layers.

### Description
- Add a new `hospitication` package with core contracts and configuration in `core/` including `config.py`, `types.py`, and a deterministic `AnalyzerRegistry` in `registry.py`.
- Implement analyzers in `analysis/` (`cognitive_cost`, `dependency_fatigue`, `recovery_resistance`, `replay_complexity`, `semantic_pressure`) plus shared helpers for file classification and scoring.
- Implement the signal pipeline in `signal/` with a read-only `observer`, pattern `detector`, deterministic `emitter`, and `envelopes` helpers, plus file observation parsing and import extraction.
- Add recovery layer (`recovery/`) that generates non-destructive `RecoveryProposal`s and a text `MITIGATIONS` catalog, plus deterministic reporters in `reporter/` for JSON and Markdown.
- Provide a CLI entrypoint `cli.py` with `build_report` and `main` to render deterministic Markdown/JSON and a package-level `__init__` exposing `VERSION`.
- Add docs (`docs/ARCHITECTURE.md`, `docs/CLI.md`) and update `README.md` to describe scope, guarantees, package layout, and CLI examples.

### Testing
- Ran unit and integration tests with `python -m pytest tests/test_hospitication_core.py tests/test_hospitication_cli.py`, which exercise the observer, deterministic report pipeline, signal emission, and proposal generation, and these tests succeeded.
- The CLI JSON/Markdown behaviors are validated by `tests/test_hospitication_cli.py` which invokes the CLI and asserts output and generated timestamp correctness, and those assertions passed.
- Deterministic rendering is validated by `tests/test_hospitication_core.py` which compares `render_json` outputs across runs and checks immutability contracts, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183fc298408332bcd7fff25ac986e9)