### PR TITLE
fix: restore BOX suggestions in Cross-L plans

### DIFF
--- a/.github/workflows/croll.yml
+++ b/.github/workflows/croll.yml
@@ -5,11 +5,21 @@ on:
     paths:
       - "croll/**"
       - "docs/croll/**"
+      - "wx/**"
+      - "w3_api/**"
+      - "config/**"
+      - "tests/test_box_integration.py"
+      - "tests/test_cross_x_config.py"
       - ".github/workflows/croll.yml"
   pull_request:
     paths:
       - "croll/**"
       - "docs/croll/**"
+      - "wx/**"
+      - "w3_api/**"
+      - "config/**"
+      - "tests/test_box_integration.py"
+      - "tests/test_cross_x_config.py"
       - ".github/workflows/croll.yml"
   workflow_dispatch:
 
@@ -41,17 +51,54 @@ jobs:
 
       - name: Check repository paths are cross-platform
         run: python tools/check_portable_paths.py
-      - name: Compile CROLL
-        run: python -m compileall croll
+      - name: Compile CROLL and BOX
+        run: python -m compileall croll wx
 
       - name: Run CROLL tests
         run: python -m unittest discover -s croll -p "test_*.py" -v
 
+      - name: Run BOX Engine-Index tests
+        run: python -m unittest discover -s wx -p "test_*.py" -v
+
       - name: Smoke-test portable CLI
-        run: python -m croll --compact plan "PX:[2,1]"
+        run: |
+          python -m croll --compact plan "PX:[2,1]"
+          python -m croll --compact plan "PX:[1,1]" --box-suggestion
 
       - name: Validate shipped CROLL contracts
         run: |
           python -m croll validate boundary croll/examples/boundary.w3-internal.json
           python -m croll validate workset croll/examples/workset.rock.json
           python -m croll validate plan croll/examples/dispatch-plan.jazz.json
+
+
+  box-api:
+    name: BOX / W3-API integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install API test dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements.txt
+
+      - name: Validate BOX registry schema
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from jsonschema import Draft202012Validator
+          schema = json.loads(Path("wx/registry/template_registry.schema.json").read_text(encoding="utf-8"))
+          registry = json.loads(Path("wx/registry/template_registry.json").read_text(encoding="utf-8"))
+          Draft202012Validator.check_schema(schema)
+          Draft202012Validator(schema).validate(registry)
+          PY
+
+      - name: Test BOX and W3-API integration
+        run: python -m pytest tests/test_box_integration.py tests/test_w3_api_cross_plan.py tests/test_cross_x_config.py -q

--- a/croll/cli.py
+++ b/croll/cli.py
@@ -69,6 +69,12 @@ def _parser() -> argparse.ArgumentParser:
             metavar="JSON|@FILE",
             help="Paper context as a JSON object or UTF-8 JSON file",
         )
+        if name == "plan":
+            command.add_argument(
+                "--box-suggestion",
+                action="store_true",
+                help="include a read-only BOX template suggestion",
+            )
 
     commands.add_parser("list", help="list registered Table-X coordinates")
     validate = commands.add_parser("validate", help="validate a CROLL JSON artifact")
@@ -92,7 +98,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command == "lookup":
         payload = get_workset_from_px(args.px, paper_context=args.context)
     elif args.command == "plan":
-        payload = dispatch_workset(args.px, paper_context=args.context)
+        payload = dispatch_workset(
+            args.px,
+            paper_context=args.context,
+            enable_box_suggestion=args.box_suggestion,
+        )
     elif args.command == "validate":
         try:
             artifact = json.loads(args.file.read_text(encoding="utf-8"))

--- a/croll/cross_l_dispatcher.py
+++ b/croll/cross_l_dispatcher.py
@@ -34,7 +34,12 @@ def _unknown_workset(workset: Dict[str, Any]) -> bool:
     return workset.get("rytm") == "UNKNOWN" or workset.get("work_type") == "UNKNOWN"
 
 
-def dispatch_workset(px: Any, paper_context: Optional[Mapping[str, Any]] = None) -> DispatchPlan:
+def dispatch_workset(
+    px: Any,
+    paper_context: Optional[Mapping[str, Any]] = None,
+    *,
+    enable_box_suggestion: bool = False,
+) -> DispatchPlan:
     """
     Build a safe dispatch plan from a PX reference.
 
@@ -42,6 +47,8 @@ def dispatch_workset(px: Any, paper_context: Optional[Mapping[str, Any]] = None)
         px: PX reference, e.g. "1,1", "PX:[1,1]", [1, 1], or (1, 1).
         paper_context: Optional Cross-L paper context. This function only passes the
             context into Table-X lookup for trace markers. It does not execute anything.
+        enable_box_suggestion: When true, add one read-only BOX registry suggestion.
+            The lookup does not copy, write, execute, or grant new authority.
 
     Returns:
         A dispatch plan with execution_allowed=False and mutated=False always.
@@ -80,7 +87,25 @@ def dispatch_workset(px: Any, paper_context: Optional[Mapping[str, Any]] = None)
                 "action": "review_before_dispatch",
             }
         )
-        return plan
+
+    if enable_box_suggestion:
+        # Lazy import keeps CROLL usable as a standalone planner when BOX is absent.
+        from wx.engine_index import search_by_px
+
+        template = search_by_px(workset.get("px"))
+        plan["suggested_template"] = (
+            {
+                "template_id": template["template_id"],
+                "name": template["name"],
+                "path": template["path"],
+                "version": template["version"],
+                "boundary": template["boundary"],
+                "deny": list(template["deny"]),
+                "reference_only": True,
+            }
+            if template
+            else None
+        )
 
     return plan
 

--- a/croll/test_cli.py
+++ b/croll/test_cli.py
@@ -30,6 +30,13 @@ class TestCrossLCli(unittest.TestCase):
         self.assertFalse(payload["execution_allowed"])
         self.assertEqual(payload["workset"]["paper_context_keys"], ["paper_id"])
 
+    def test_plan_can_request_box_suggestion(self):
+        result = self.run_cli("plan", "1,1", "--box-suggestion")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["suggested_template"]["reference_only"])
+        self.assertFalse(payload["execution_allowed"])
+
     def test_plan_forces_utf8_on_legacy_console_encoding(self):
         result = self.run_cli(
             "--compact",

--- a/croll/test_cross_l_dispatcher.py
+++ b/croll/test_cross_l_dispatcher.py
@@ -60,6 +60,18 @@ class TestCrossLDispatcher(unittest.TestCase):
         self.assertEqual(plan["workset"]["rytm"], "UNKNOWN")
         self.assertIn("Invalid PX format", plan["reason"])
 
+    def test_dispatch_can_include_read_only_box_suggestion(self):
+        plan = dispatch_workset("1,1", enable_box_suggestion=True)
+        self.assert_safe_plan(plan)
+        suggestion = plan["suggested_template"]
+        self.assertTrue(suggestion["reference_only"])
+        self.assertTrue(suggestion["path"].startswith("wx/templates/"))
+
+    def test_dispatch_box_suggestion_falls_back_to_none(self):
+        plan = dispatch_workset("99,99", enable_box_suggestion=True)
+        self.assert_safe_plan(plan)
+        self.assertIsNone(plan["suggested_template"])
+
     def test_dispatch_with_paper_context_marker(self):
         plan = dispatch_workset("1,1", paper_context={"paper_id": "demo", "scope": "CROSS_L_ONLY"})
         self.assert_safe_plan(plan)

--- a/w3_api/models.py
+++ b/w3_api/models.py
@@ -32,11 +32,13 @@ class W3CrossPlanRequest(BaseModel):
 
     px: str = Field(..., min_length=1)
     paper_context: dict[str, Any] | None = None
+    include_box_suggestion: bool = False
 
 
 class W3CrossPlanResponse(BaseModel):
     """Safe dispatch plan from Cross-L dispatcher."""
 
+    contract_version: str = "1.0"
     state: str
     reason: str
     scope: str
@@ -49,3 +51,4 @@ class W3CrossPlanResponse(BaseModel):
     review: bool
     workset: dict[str, Any]
     safety: dict[str, bool]
+    suggested_template: dict[str, Any] | None = None

--- a/w3_api/router.py
+++ b/w3_api/router.py
@@ -58,7 +58,11 @@ def cross(req: W3CrossRequest) -> W3CrossResponse:
     )
 
 
-@router.post("/cross/plan", response_model=W3CrossPlanResponse)
+@router.post(
+    "/cross/plan",
+    response_model=W3CrossPlanResponse,
+    response_model_exclude_none=True,
+)
 def cross_plan(req: W3CrossPlanRequest) -> W3CrossPlanResponse:
     """Return a safe Cross-L dispatch plan from a PX reference.
 
@@ -66,5 +70,9 @@ def cross_plan(req: W3CrossPlanRequest) -> W3CrossPlanResponse:
     write repository files, merge changes, or call external systems.
     """
 
-    plan = dispatch_workset(req.px, paper_context=req.paper_context)
+    plan = dispatch_workset(
+        req.px,
+        paper_context=req.paper_context,
+        enable_box_suggestion=req.include_box_suggestion,
+    )
     return W3CrossPlanResponse(**plan)


### PR DESCRIPTION
### Motivation
- A regression removed the optional BOX suggestion flow from Cross-L planner and W3-API, causing API responses to lack `suggested_template` and failing `tests/test_box_integration.py`.
- The intent is to re-enable read-only BOX template suggestions while keeping planner outputs non-executing and read-only.

### Description
- Reintroduced `include_box_suggestion: bool` on `W3CrossPlanRequest` and added `suggested_template` to `W3CrossPlanResponse` so suggestions are included only when requested.
- Restored route behavior in `/w3/cross/plan` to forward `include_box_suggestion` to `dispatch_workset` via the `enable_box_suggestion` flag.
- Reinstated BOX lookup in `croll.cross_l_dispatcher.dispatch_workset` with a lazy import of `wx.engine_index.search_by_px` and a `reference_only` suggestion payload when a template is found.
- Added CLI option `--box-suggestion` to the `croll` `plan` command and re-enabled related unit tests and the dedicated CI job and smoke tests in `.github/workflows/croll.yml`.

### Testing
- Ran `python -m compileall -q croll wx w3_api` and compilation succeeded.
- Ran `python -m unittest discover -s croll -p 'test_*.py' -v` and `python -m unittest discover -s wx -p 'test_*.py' -v` and both suites passed.
- Ran `python -m pytest tests/test_box_integration.py tests/test_w3_api_cross_plan.py tests/test_cross_x_config.py -q` and the targeted pytest suite passed (13 tests).
- Executed CLI smoke and registry validation: `python -m croll --compact plan 'PX:[1,1]' --box-suggestion` and BOX registry validation with `Draft202012Validator`, both succeeded.
- Note: a repository-wide `python -m pytest -q` run aborted during collection due to an unrelated test file calling `sys.exit()` at import time; this is outside the scope of the changes and did not affect the targeted suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba68fe81083329ff04fd5f2133738)