### PR TITLE
Add Event-Chain (E-CS), MPCP adapter, W3Lgu operational runtime, BOX suggestions, and CI updates

### DIFF
--- a/.github/workflows/croll.yml
+++ b/.github/workflows/croll.yml
@@ -4,12 +4,28 @@ on:
   push:
     paths:
       - "croll/**"
+      - "cross_x/**"
+      - "protocol/mpcp/**"
       - "docs/croll/**"
+      - "wx/**"
+      - "w3_api/**"
+      - "config/**"
+      - "tests/test_box_integration.py"
+      - "tests/test_cross_x_config.py"
+      - "tests/test_cross_mpcp_adapter.py"
       - ".github/workflows/croll.yml"
   pull_request:
     paths:
       - "croll/**"
+      - "cross_x/**"
+      - "protocol/mpcp/**"
       - "docs/croll/**"
+      - "wx/**"
+      - "w3_api/**"
+      - "config/**"
+      - "tests/test_box_integration.py"
+      - "tests/test_cross_x_config.py"
+      - "tests/test_cross_mpcp_adapter.py"
       - ".github/workflows/croll.yml"
   workflow_dispatch:
 
@@ -41,17 +57,54 @@ jobs:
 
       - name: Check repository paths are cross-platform
         run: python tools/check_portable_paths.py
-      - name: Compile CROLL
-        run: python -m compileall croll
+      - name: Compile CROLL, Cross-X, MPCP and BOX
+        run: python -m compileall croll cross_x protocol/mpcp wx
 
       - name: Run CROLL tests
         run: python -m unittest discover -s croll -p "test_*.py" -v
 
+      - name: Run BOX Engine-Index tests
+        run: python -m unittest discover -s wx -p "test_*.py" -v
+
       - name: Smoke-test portable CLI
-        run: python -m croll --compact plan "PX:[2,1]"
+        run: |
+          python -m croll --compact plan "PX:[2,1]"
+          python -m croll --compact plan "PX:[1,1]" --box-suggestion
 
       - name: Validate shipped CROLL contracts
         run: |
           python -m croll validate boundary croll/examples/boundary.w3-internal.json
           python -m croll validate workset croll/examples/workset.rock.json
           python -m croll validate plan croll/examples/dispatch-plan.jazz.json
+
+
+  box-api:
+    name: BOX / W3-API integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install API test dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements.txt
+
+      - name: Validate BOX registry schema
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from jsonschema import Draft202012Validator
+          schema = json.loads(Path("wx/registry/template_registry.schema.json").read_text(encoding="utf-8"))
+          registry = json.loads(Path("wx/registry/template_registry.json").read_text(encoding="utf-8"))
+          Draft202012Validator.check_schema(schema)
+          Draft202012Validator(schema).validate(registry)
+          PY
+
+      - name: Test BOX and W3-API integration
+        run: python -m pytest tests/test_box_integration.py tests/test_w3_api_cross_plan.py tests/test_cross_x_config.py tests/test_cross_mpcp_adapter.py -q

--- a/config/cross_system.json
+++ b/config/cross_system.json
@@ -16,7 +16,8 @@
     "diagnose": false,
     "execute": false,
     "requires_human_review": true,
-    "requires_governance_gate": true
+    "requires_governance_gate": true,
+    "event_chain_supervisor": "AI_SUPERVISOR"
   },
   "chain": [
     "W3-API",

--- a/config/loader.py
+++ b/config/loader.py
@@ -8,11 +8,13 @@ runtime map for Cross-X coordination.
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Union
 
 CONFIG_ROOT = Path(__file__).resolve().parent
+_ECS_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 @dataclass(frozen=True)
@@ -39,7 +41,7 @@ def _load_json(path: Path) -> Mapping[str, Any]:
         return json.load(handle)
 
 
-def load_w3_config(root: str | Path = CONFIG_ROOT) -> W3ConfigBundle:
+def load_w3_config(root: Union[str, Path] = CONFIG_ROOT) -> W3ConfigBundle:
     root_path = Path(root)
     bundle = W3ConfigBundle(
         environment=_load_json(root_path / "environment.json"),
@@ -83,6 +85,40 @@ def validate_w3_config(bundle: W3ConfigBundle) -> list[str]:
         errors.append("cross_system.cross_x.requires_human_review must be true")
     if cross_x.get("requires_governance_gate") is not True:
         errors.append("cross_system.cross_x.requires_governance_gate must be true")
+    supervisor = cross_x.get("event_chain_supervisor")
+    if not isinstance(supervisor, str) or not supervisor.strip():
+        errors.append(
+            "cross_system.cross_x.event_chain_supervisor must be a non-empty string"
+        )
+    elif not _ECS_IDENTIFIER.fullmatch(supervisor.strip()):
+        errors.append(
+            "cross_system.cross_x.event_chain_supervisor must use 1-128 letters, "
+            "digits, '.', '_' or '-'"
+        )
+
+    chain = cross.get("chain", ())
+    contracts = cross.get("contracts", {})
+    if not isinstance(chain, list) or not chain:
+        errors.append("cross_system.chain must be a non-empty array")
+        valid_chain: list[str] = []
+    else:
+        valid_chain = []
+        for index, system in enumerate(chain):
+            if not isinstance(system, str) or not system.strip():
+                errors.append(
+                    f"cross_system.chain[{index}] must be a non-empty string"
+                )
+            else:
+                valid_chain.append(system.strip())
+        if len(set(valid_chain)) != len(valid_chain):
+            errors.append("cross_system.chain entries must be unique")
+
+    if not isinstance(contracts, Mapping):
+        errors.append("cross_system.contracts must be an object")
+        contracts = {}
+    for system in valid_chain:
+        if system not in contracts:
+            errors.append(f"cross_system.contracts.{system} is required")
 
     for required_path in ("w3_api", "w3lgu", "px", "w3db_append_flow", "hospitication", "iget", "codex"):
         if required_path not in paths:

--- a/croll/cli.py
+++ b/croll/cli.py
@@ -69,6 +69,12 @@ def _parser() -> argparse.ArgumentParser:
             metavar="JSON|@FILE",
             help="Paper context as a JSON object or UTF-8 JSON file",
         )
+        if name == "plan":
+            command.add_argument(
+                "--box-suggestion",
+                action="store_true",
+                help="include a read-only BOX template suggestion",
+            )
 
     commands.add_parser("list", help="list registered Table-X coordinates")
     validate = commands.add_parser("validate", help="validate a CROLL JSON artifact")
@@ -92,7 +98,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command == "lookup":
         payload = get_workset_from_px(args.px, paper_context=args.context)
     elif args.command == "plan":
-        payload = dispatch_workset(args.px, paper_context=args.context)
+        payload = dispatch_workset(
+            args.px,
+            paper_context=args.context,
+            enable_box_suggestion=args.box_suggestion,
+        )
     elif args.command == "validate":
         try:
             artifact = json.loads(args.file.read_text(encoding="utf-8"))

--- a/croll/cross_l_dispatcher.py
+++ b/croll/cross_l_dispatcher.py
@@ -19,6 +19,7 @@ Core law:
 from __future__ import annotations
 
 from collections.abc import Mapping
+import re
 from typing import Any, Dict, Optional
 
 try:
@@ -27,6 +28,8 @@ except ImportError:  # Allows direct execution: python croll/cross_l_dispatcher.
     from table_x import get_workset_from_px
 
 DispatchPlan = Dict[str, Any]
+CrossCodeEnvelope = Dict[str, Any]
+_ECS_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 
 def _unknown_workset(workset: Dict[str, Any]) -> bool:
@@ -34,7 +37,26 @@ def _unknown_workset(workset: Dict[str, Any]) -> bool:
     return workset.get("rytm") == "UNKNOWN" or workset.get("work_type") == "UNKNOWN"
 
 
-def dispatch_workset(px: Any, paper_context: Optional[Mapping[str, Any]] = None) -> DispatchPlan:
+def _normalize_ecs_identifier(value: object, *, field: str) -> str:
+    """Apply the public E-CS identifier contract at the dispatch boundary."""
+
+    if not isinstance(value, str):
+        raise ValueError(f"CrossCode dispatch {field} must be a string")
+    normalized = value.strip()
+    if not _ECS_IDENTIFIER.fullmatch(normalized):
+        raise ValueError(
+            "CrossCode dispatch requires delimiter-safe "
+            f"{field} using 1-128 letters, digits, '.', '_' or '-'"
+        )
+    return normalized
+
+
+def dispatch_workset(
+    px: Any,
+    paper_context: Optional[Mapping[str, Any]] = None,
+    *,
+    enable_box_suggestion: bool = False,
+) -> DispatchPlan:
     """
     Build a safe dispatch plan from a PX reference.
 
@@ -42,6 +64,8 @@ def dispatch_workset(px: Any, paper_context: Optional[Mapping[str, Any]] = None)
         px: PX reference, e.g. "1,1", "PX:[1,1]", [1, 1], or (1, 1).
         paper_context: Optional Cross-L paper context. This function only passes the
             context into Table-X lookup for trace markers. It does not execute anything.
+        enable_box_suggestion: When true, add one read-only BOX registry suggestion.
+            The lookup does not copy, write, execute, or grant new authority.
 
     Returns:
         A dispatch plan with execution_allowed=False and mutated=False always.
@@ -80,9 +104,95 @@ def dispatch_workset(px: Any, paper_context: Optional[Mapping[str, Any]] = None)
                 "action": "review_before_dispatch",
             }
         )
-        return plan
+
+    if enable_box_suggestion:
+        # Lazy import keeps CROLL usable as a standalone planner when BOX is absent.
+        from wx.engine_index import search_by_px
+
+        px_value = workset.get("px")
+        template = (
+            search_by_px(px_value)
+            if px_value is not None and not _unknown_workset(workset)
+            else None
+        )
+        plan["suggested_template"] = (
+            {
+                "template_id": template["template_id"],
+                "name": template["name"],
+                "path": template["path"],
+                "version": template["version"],
+                "boundary": template["boundary"],
+                "deny": list(template["deny"]),
+                "reference_only": True,
+            }
+            if template
+            else None
+        )
 
     return plan
+
+
+def dispatch_cross_code(
+    px: Any,
+    *,
+    chain_id: str,
+    event_id: str,
+    paper_context: Optional[Mapping[str, Any]] = None,
+    enable_box_suggestion: bool = False,
+    active: bool = True,
+) -> CrossCodeEnvelope:
+    """Bind a Cross-L plan to one E-CS event without executing CrossCode.
+
+    The envelope is the Cross-Series handoff contract: E-CS supplies trace
+    identity, Cross-L supplies bounded work logic, and Modew remains a stub
+    target until human review and governance approve a separate execution step.
+    """
+
+    chain_id = _normalize_ecs_identifier(chain_id, field="chain_id")
+    event_id = _normalize_ecs_identifier(event_id, field="event_id")
+    if not active:
+        return {
+            "contract_version": "1.0",
+            "kind": "cross-code-dispatch",
+            "chain_id": chain_id,
+            "event_id": event_id,
+            "state": "inactive",
+            "reason": "cross_code_not_in_use",
+            "cross_l_plan": None,
+            "handoff": None,
+            "return_value": {
+                "state": "inactive",
+                "handled": True,
+                "execution_allowed": False,
+                "mutated": False,
+            },
+            "execution_allowed": False,
+            "mutated": False,
+            "review": False,
+        }
+    plan = dispatch_workset(
+        px,
+        paper_context=paper_context,
+        enable_box_suggestion=enable_box_suggestion,
+    )
+    return {
+        "contract_version": "1.0",
+        "kind": "cross-code-dispatch",
+        "chain_id": chain_id,
+        "event_id": event_id,
+        "state": plan["state"],
+        "cross_l_plan": plan,
+        "handoff": {
+            "from": "Cross-L",
+            "to": "Modew",
+            "action": plan["action"],
+            "boundary": plan["workset"]["boundary"],
+            "return_contract": list(plan["workset"].get("return_contract", [])),
+        },
+        "execution_allowed": False,
+        "mutated": False,
+        "review": True,
+    }
 
 
 if __name__ == "__main__":

--- a/croll/test_cli.py
+++ b/croll/test_cli.py
@@ -30,6 +30,13 @@ class TestCrossLCli(unittest.TestCase):
         self.assertFalse(payload["execution_allowed"])
         self.assertEqual(payload["workset"]["paper_context_keys"], ["paper_id"])
 
+    def test_plan_can_request_box_suggestion(self):
+        result = self.run_cli("plan", "1,1", "--box-suggestion")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["suggested_template"]["reference_only"])
+        self.assertFalse(payload["execution_allowed"])
+
     def test_plan_forces_utf8_on_legacy_console_encoding(self):
         result = self.run_cli(
             "--compact",

--- a/croll/test_cross_l_dispatcher.py
+++ b/croll/test_cross_l_dispatcher.py
@@ -1,6 +1,6 @@
 import unittest
 
-from croll.cross_l_dispatcher import dispatch_workset
+from croll.cross_l_dispatcher import dispatch_cross_code, dispatch_workset
 
 
 class TestCrossLDispatcher(unittest.TestCase):
@@ -60,12 +60,92 @@ class TestCrossLDispatcher(unittest.TestCase):
         self.assertEqual(plan["workset"]["rytm"], "UNKNOWN")
         self.assertIn("Invalid PX format", plan["reason"])
 
+    def test_dispatch_can_include_read_only_box_suggestion(self):
+        plan = dispatch_workset("1,1", enable_box_suggestion=True)
+        self.assert_safe_plan(plan)
+        suggestion = plan["suggested_template"]
+        self.assertTrue(suggestion["reference_only"])
+        self.assertTrue(suggestion["path"].startswith("wx/templates/"))
+
+    def test_dispatch_box_suggestion_falls_back_to_none(self):
+        plan = dispatch_workset("99,99", enable_box_suggestion=True)
+        self.assert_safe_plan(plan)
+        self.assertIsNone(plan["suggested_template"])
+
+    def test_invalid_px_never_receives_unrelated_box_suggestion(self):
+        plan = dispatch_workset("invalid", enable_box_suggestion=True)
+        self.assert_safe_plan(plan)
+        self.assertEqual(plan["state"], "review")
+        self.assertIsNone(plan["px"])
+        self.assertIsNone(plan["suggested_template"])
+
     def test_dispatch_with_paper_context_marker(self):
         plan = dispatch_workset("1,1", paper_context={"paper_id": "demo", "scope": "CROSS_L_ONLY"})
         self.assert_safe_plan(plan)
         self.assertEqual(plan["state"], "planned")
         self.assertTrue(plan["workset"]["paper_context_received"])
         self.assertEqual(plan["workset"]["paper_context_keys"], ["paper_id", "scope"])
+
+    def test_cross_code_dispatch_binds_plan_to_ecs_event(self):
+        envelope = dispatch_cross_code(
+            "2,1",
+            chain_id="cross-test",
+            event_id="ECS-06-TEST",
+            paper_context={"event_system": "PX"},
+        )
+
+        self.assertEqual(envelope["kind"], "cross-code-dispatch")
+        self.assertEqual(envelope["chain_id"], "cross-test")
+        self.assertEqual(envelope["event_id"], "ECS-06-TEST")
+        self.assertEqual(envelope["handoff"]["from"], "Cross-L")
+        self.assertEqual(envelope["handoff"]["to"], "Modew")
+        self.assertEqual(envelope["handoff"]["boundary"], "observe")
+        self.assertFalse(envelope["execution_allowed"])
+        self.assertFalse(envelope["mutated"])
+        self.assertTrue(envelope["review"])
+
+    def test_cross_code_dispatch_requires_trace_identity(self):
+        with self.assertRaisesRegex(ValueError, "chain_id"):
+            dispatch_cross_code("1,1", chain_id="", event_id="ECS-01")
+
+    def test_cross_code_dispatch_rejects_unsafe_trace_identity(self):
+        with self.assertRaisesRegex(ValueError, "delimiter-safe chain_id"):
+            dispatch_cross_code(
+                "1,1",
+                chain_id="cross,CHAIN_ID:override",
+                event_id="ECS-01",
+            )
+        with self.assertRaisesRegex(ValueError, "event_id must be a string"):
+            dispatch_cross_code(
+                "1,1",
+                chain_id="cross-safe",
+                event_id=None,
+            )
+
+    def test_cross_code_dispatch_normalizes_trace_identity(self):
+        envelope = dispatch_cross_code(
+            "1,1",
+            chain_id="  cross-safe  ",
+            event_id="  ECS-01-SAFE  ",
+        )
+        self.assertEqual(envelope["chain_id"], "cross-safe")
+        self.assertEqual(envelope["event_id"], "ECS-01-SAFE")
+
+    def test_inactive_cross_code_returns_handled_value_without_plan(self):
+        envelope = dispatch_cross_code(
+            "1,1",
+            chain_id="cross-inactive",
+            event_id="ECS-01-INACTIVE",
+            active=False,
+        )
+
+        self.assertEqual(envelope["state"], "inactive")
+        self.assertEqual(envelope["reason"], "cross_code_not_in_use")
+        self.assertIsNone(envelope["cross_l_plan"])
+        self.assertIsNone(envelope["handoff"])
+        self.assertTrue(envelope["return_value"]["handled"])
+        self.assertFalse(envelope["execution_allowed"])
+        self.assertFalse(envelope["mutated"])
 
 
 if __name__ == "__main__":

--- a/cross_x/README.md
+++ b/cross_x/README.md
@@ -9,6 +9,7 @@ W3 can improve the working method:
 Intent
 → W3-API shape
 → W3Lgu five-line packet
+→ E-CS immutable event handoffs
 → PX position pointer
 → W3DB append envelope
 → EP_SIGNAL preview
@@ -18,9 +19,14 @@ Intent
 Default behavior is plan-only and non-mutating. Cross-X does not execute MPCP,
 persist W3DB records, mutate EP_SIGNAL payloads, or approve source truth.
 
+W3Lgu packets carry the E-CS `CHAIN_ID`, planned event state, and an explicit
+`EXECUTE_ALLOWED:false` signal. E-CS then expands the configured system order
+into traceable records; it coordinates handoffs but does not run the systems.
+
 ## Code
 
 - `cross_x/core.py` — immutable request/plan contracts and `build_cross_x_plan`
+- `cross_x/event_chain.py` — immutable E-CS event and chain contracts
 - `config/cross_system.json` — Cross-X ecosystem policy
 - `config/ecosystem.json` — participating systems
 - `config/paths.json` — canonical subsystem paths

--- a/cross_x/__init__.py
+++ b/cross_x/__init__.py
@@ -1,5 +1,41 @@
 """Cross-X ecosystem coordination package."""
 
 from cross_x.core import CrossXPlan, CrossXRequest, build_cross_x_plan
+from cross_x.audit import audit_cross_systems
+from cross_x.event_chain import (
+    EventChain,
+    EventChainRecord,
+    bind_event_return,
+    build_event_chain,
+    freeze_ecs_mapping,
+    normalize_ecs_identifier,
+    thaw_ecs_mapping,
+)
+from cross_x.mpcp_adapter import (
+    CROSS_MPCP_ADAPTER_VERSION,
+    EXECUTION_CAPABILITY,
+    CrossMPCPResult,
+    MPCPExecutionApproval,
+    build_cross_mpcp_handoff,
+    execute_cross_handoff,
+)
 
-__all__ = ["CrossXPlan", "CrossXRequest", "build_cross_x_plan"]
+__all__ = [
+    "CrossXPlan",
+    "CrossXRequest",
+    "EventChain",
+    "EventChainRecord",
+    "CrossMPCPResult",
+    "MPCPExecutionApproval",
+    "CROSS_MPCP_ADAPTER_VERSION",
+    "EXECUTION_CAPABILITY",
+    "bind_event_return",
+    "build_cross_mpcp_handoff",
+    "freeze_ecs_mapping",
+    "build_cross_x_plan",
+    "build_event_chain",
+    "audit_cross_systems",
+    "normalize_ecs_identifier",
+    "thaw_ecs_mapping",
+    "execute_cross_handoff",
+]

--- a/cross_x/audit.py
+++ b/cross_x/audit.py
@@ -1,0 +1,67 @@
+"""Cross-X configuration audit helpers.
+
+The audit reports integration readiness only.  It never imports, starts, or
+executes a configured subsystem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Optional, Union
+
+from config.loader import W3ConfigBundle
+
+
+def audit_cross_systems(
+    config: W3ConfigBundle,
+    *,
+    repository_root: Optional[Union[str, Path]] = None,
+) -> dict[str, Any]:
+    """Audit chain membership, contracts, status, and repository paths."""
+
+    root = Path(repository_root) if repository_root is not None else Path(__file__).resolve().parent.parent
+    components: Mapping[str, Any] = config.ecosystem.get("components", {})
+    contracts: Mapping[str, Any] = config.cross_system.get("contracts", {})
+    chain = tuple(config.cross_system.get("chain", ()))
+    records = []
+    issues = []
+
+    for system in chain:
+        component = components.get(system)
+        system_issues = []
+        if not isinstance(component, Mapping):
+            system_issues.append("component_not_registered")
+            component = {}
+        path_value = component.get("path")
+        path_exists = isinstance(path_value, str) and bool(path_value) and (root / path_value).exists()
+        if not path_exists:
+            system_issues.append("component_path_missing")
+        if system not in contracts:
+            system_issues.append("contract_missing")
+
+        configured_state = str(component.get("status", "active")).strip().lower()
+        active = configured_state in {"active", "ready", "enabled"}
+        if not active:
+            system_issues.append("system_inactive")
+
+        records.append(
+            {
+                "system": system,
+                "status": "ready" if not system_issues else "attention",
+                "configured_state": configured_state,
+                "active": active,
+                "path": path_value,
+                "path_exists": path_exists,
+                "contract": contracts.get(system),
+                "issues": system_issues,
+            }
+        )
+        issues.extend(f"{system}:{issue}" for issue in system_issues)
+
+    return {
+        "status": "ready" if not issues else "attention",
+        "mutated": False,
+        "checked": len(records),
+        "issues": issues,
+        "systems": records,
+    }

--- a/cross_x/core.py
+++ b/cross_x/core.py
@@ -10,36 +10,42 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 from uuid import uuid4
 
 from config.loader import W3ConfigBundle, load_w3_config
 from protocol.EP_SIGNAL.ep_signal_adapter import to_ep_signal
 from core.runtime.process_layer import run_w3_process_layer
 from protocol.EP_SIGNAL.rytm import build_rytm_preview
-from protocol.w3lgu import W3LguFiveLineProgram, parse_five_line_program, px_from_five_line, px_to_append_envelope, validate_five_line
+from protocol.w3lgu import W3LguFiveLineProgram, encode_w3lgu_value, parse_five_line_program, px_from_five_line, px_to_append_envelope, validate_five_line
 from protocol.w3lgu.px import PXAnchor
 from src.w3db.append_flow import AppendEnvelope
+from cross_x.event_chain import EventChain, build_event_chain, normalize_ecs_identifier
+from cross_x.audit import audit_cross_systems
 
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def _clean(value: object) -> str:
-    return " ".join(str(value).replace("\n", " ").replace("\r", " ").split())
-
-
-def _build_cross_w3lgu_packet(*, source: str, intent: str, target: str | None, mode: str, payload: Mapping[str, Any]) -> W3LguFiveLineProgram:
+def _build_cross_w3lgu_packet(
+    *,
+    chain_id: str,
+    source: str,
+    intent: str,
+    target: Optional[str],
+    mode: str,
+    payload: Mapping[str, Any],
+) -> W3LguFiveLineProgram:
     target_value = target or "auto"
     contract = str(payload.get("contract", "observe_only"))
     text = "\n".join(
         (
-            f"MEM:SOURCE:{_clean(source)}",
-            f"PATCH:MODE:{_clean(mode)}",
-            f"LAW:TARGET:{_clean(target_value)},CONTRACT:{_clean(contract)}",
-            f"EVENT:INTENT:{_clean(intent)}",
-            "SIGNAL:STATUS:received,TRACEABLE:true",
+            f"MEM:SOURCE:{encode_w3lgu_value(source)},CHAIN_ID:{chain_id}",
+            f"PATCH:MODE:{encode_w3lgu_value(mode)}",
+            f"LAW:TARGET:{encode_w3lgu_value(target_value)},CONTRACT:{encode_w3lgu_value(contract)}",
+            f"EVENT:INTENT:{encode_w3lgu_value(intent)},ECS_STATE:planned",
+            "SIGNAL:STATUS:received,TRACEABLE:true,EXECUTE_ALLOWED:false",
         )
     )
     program = parse_five_line_program(text)
@@ -67,7 +73,7 @@ class CrossXRequest:
 
     source: str
     intent: str
-    target: str | None = None
+    target: Optional[str] = None
     mode: str = "observe"
     payload: Mapping[str, Any] = field(default_factory=dict)
 
@@ -93,11 +99,13 @@ class CrossXPlan:
     timestamp: str
     request: CrossXRequest
     chain: tuple[str, ...]
+    event_chain: EventChain
     program: W3LguFiveLineProgram
     px: PXAnchor
     append_envelope: AppendEnvelope
     ep_signal: Mapping[str, Any]
     process_trace: Mapping[str, Any] = field(default_factory=dict)
+    system_audit: Mapping[str, Any] = field(default_factory=dict)
     status: str = "planned"
     mutated: bool = False
     governance: Mapping[str, bool] = field(
@@ -117,26 +125,28 @@ class CrossXPlan:
             "mutated": self.mutated,
             "request": self.request.to_dict(),
             "chain": list(self.chain),
+            "event_chain": self.event_chain.to_dict(),
             "w3lgu": self.program.to_text(),
             "px": self.px.to_dict(),
             "append_envelope": self.append_envelope.to_dict(),
             "ep_signal": dict(self.ep_signal),
             "process_trace": dict(self.process_trace),
+            "system_audit": dict(self.system_audit),
             "governance": dict(self.governance),
         }
 
 
 def build_cross_x_plan(
-    request: CrossXRequest | None = None,
+    request: Optional[CrossXRequest] = None,
     *,
-    source: str | None = None,
-    intent: str | None = None,
-    target: str | None = None,
-    mode: str | None = None,
-    payload: Mapping[str, Any] | None = None,
-    config: W3ConfigBundle | None = None,
-    cross_id: str | None = None,
-    timestamp: str | None = None,
+    source: Optional[str] = None,
+    intent: Optional[str] = None,
+    target: Optional[str] = None,
+    mode: Optional[str] = None,
+    payload: Optional[Mapping[str, Any]] = None,
+    config: Optional[W3ConfigBundle] = None,
+    cross_id: Optional[str] = None,
+    timestamp: Optional[str] = None,
 ) -> CrossXPlan:
     """Build a non-mutating Cross-X coordination plan."""
 
@@ -153,7 +163,12 @@ def build_cross_x_plan(
     if resolved_request.mode not in allowed_modes:
         raise ValueError(f"Cross-X mode {resolved_request.mode!r} is not allowed")
 
+    resolved_cross_id = normalize_ecs_identifier(
+        str(uuid4()) if cross_id is None else cross_id,
+        field="chain_id",
+    )
     program = _build_cross_w3lgu_packet(
+        chain_id=resolved_cross_id,
         source=resolved_request.source,
         intent=resolved_request.intent,
         target=resolved_request.target,
@@ -165,7 +180,7 @@ def build_cross_x_plan(
         relation="cross_x.workflow_improvement",
         mode=resolved_request.mode,
         extra_payload={
-            "cross_id": cross_id or "pending",
+            "cross_id": resolved_cross_id,
             "purpose": cross_x["purpose"],
             "truth_mutation": cross_x["truth_mutation"],
         },
@@ -177,17 +192,30 @@ def build_cross_x_plan(
         target=resolved_request.target,
         mode=resolved_request.mode,
         payload=resolved_request.payload,
-        process_id=cross_id,
+        process_id=resolved_cross_id,
         timestamp=timestamp,
     ).to_dict()
+    system_audit = audit_cross_systems(cfg)
+    component_states = {
+        system: str(cfg.ecosystem["components"].get(system, {}).get("status", "active"))
+        for system in cfg.cross_system["chain"]
+    }
     return CrossXPlan(
-        cross_id=cross_id or str(uuid4()),
+        cross_id=resolved_cross_id,
         timestamp=timestamp or _now_iso(),
         request=resolved_request,
         chain=tuple(cfg.cross_system["chain"]),
+        event_chain=build_event_chain(
+            chain_id=resolved_cross_id,
+            systems=tuple(cfg.cross_system["chain"]),
+            contracts=cfg.cross_system["contracts"],
+            system_states=component_states,
+            supervisor=str(cross_x.get("event_chain_supervisor", "AI_SUPERVISOR")),
+        ),
         program=program,
         px=px,
         append_envelope=append_envelope,
         ep_signal=_build_ep_signal_preview(program.to_text()),
         process_trace=process_trace,
+        system_audit=system_audit,
     )

--- a/cross_x/event_chain.py
+++ b/cross_x/event_chain.py
@@ -1,0 +1,285 @@
+"""Immutable Event-Chain System (E-CS) contracts for Cross-Series.
+
+E-CS makes the configured Cross-X chain observable as ordered handoffs.  It
+does not run subsystems: every event is a plan record carrying the subsystem
+contract, predecessor, and governance boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Sequence
+
+ECS_CONTRACT_VERSION = "1.0"
+_ECS_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_TERMINAL_EVENT_STATES = frozenset({"completed", "stopped", "inactive"})
+
+
+def freeze_ecs_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a recursively immutable copy suitable for E-CS history."""
+
+    if not isinstance(value, Mapping):
+        raise TypeError("E-CS value must be a mapping")
+    return MappingProxyType(
+        {str(key): _freeze_ecs_value(item) for key, item in value.items()}
+    )
+
+
+def thaw_ecs_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a JSON-friendly copy of an immutable E-CS mapping."""
+
+    return {str(key): _thaw_ecs_value(item) for key, item in value.items()}
+
+
+def _freeze_ecs_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return freeze_ecs_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_ecs_value(item) for item in value)
+    if isinstance(value, set):
+        return tuple(sorted((_freeze_ecs_value(item) for item in value), key=repr))
+    return value
+
+
+def _thaw_ecs_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return thaw_ecs_mapping(value)
+    if isinstance(value, tuple):
+        return [_thaw_ecs_value(item) for item in value]
+    return value
+
+
+def normalize_ecs_identifier(value: object, *, field: str) -> str:
+    """Return a delimiter-safe E-CS identifier or reject it.
+
+    E-CS identifiers are embedded in W3Lgu values, so commas, colons, line
+    breaks, and other packet delimiters are intentionally forbidden.
+    """
+
+    if not isinstance(value, str):
+        raise ValueError(f"E-CS {field} must be a string")
+    normalized = value.strip()
+    if not _ECS_IDENTIFIER.fullmatch(normalized):
+        raise ValueError(
+            f"E-CS {field} must use 1-128 letters, digits, '.', '_' or '-'"
+        )
+    return normalized
+
+
+def _stable_event_id(chain_id: str, sequence: int, system: str) -> str:
+    body = json.dumps(
+        {"chain_id": chain_id, "sequence": sequence, "system": system},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest().upper()[:12]
+    return f"ECS-{sequence:02d}-{digest}"
+
+
+@dataclass(frozen=True)
+class EventChainRecord:
+    """One ordered, non-executing handoff in an E-CS chain."""
+
+    event_id: str
+    chain_id: str
+    sequence: int
+    system: str
+    contract: str
+    predecessor: Optional[str]
+    successor: Optional[str]
+    status: str = "planned"
+    return_value: Optional[Mapping[str, Any]] = None
+    return_history: tuple[Mapping[str, Any], ...] = ()
+    mutated: bool = False
+    execute_allowed: bool = False
+
+    def __post_init__(self) -> None:
+        if self.return_value is not None:
+            object.__setattr__(
+                self,
+                "return_value",
+                freeze_ecs_mapping(self.return_value),
+            )
+        object.__setattr__(
+            self,
+            "return_history",
+            tuple(freeze_ecs_mapping(item) for item in self.return_history),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "chain_id": self.chain_id,
+            "sequence": self.sequence,
+            "system": self.system,
+            "contract": self.contract,
+            "predecessor": self.predecessor,
+            "successor": self.successor,
+            "status": self.status,
+            "return_value": thaw_ecs_mapping(self.return_value)
+            if self.return_value is not None
+            else None,
+            "return_history": [
+                thaw_ecs_mapping(item) for item in self.return_history
+            ],
+            "mutated": self.mutated,
+            "execute_allowed": self.execute_allowed,
+        }
+
+
+@dataclass(frozen=True)
+class EventChain:
+    """Complete E-CS plan for a Cross-X coordination request."""
+
+    chain_id: str
+    events: tuple[EventChainRecord, ...]
+    contract_version: str = ECS_CONTRACT_VERSION
+    state: str = "planned"
+    supervisor: str = "AI_SUPERVISOR"
+    mutated: bool = False
+    human_review_required: bool = True
+    governance_gate_required: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": self.contract_version,
+            "chain_id": self.chain_id,
+            "state": self.state,
+            "supervisor": self.supervisor,
+            "mutated": self.mutated,
+            "human_review_required": self.human_review_required,
+            "governance_gate_required": self.governance_gate_required,
+            "events": [event.to_dict() for event in self.events],
+        }
+
+
+def build_event_chain(
+    *,
+    chain_id: str,
+    systems: Sequence[str],
+    contracts: Mapping[str, Any],
+    system_states: Optional[Mapping[str, str]] = None,
+    supervisor: str = "AI_SUPERVISOR",
+) -> EventChain:
+    """Build a deterministic E-CS handoff plan from configured systems."""
+
+    chain_id = normalize_ecs_identifier(chain_id, field="chain_id")
+    supervisor = normalize_ecs_identifier(supervisor, field="supervisor")
+    if not systems:
+        raise ValueError("E-CS requires at least one system")
+    if isinstance(systems, (str, bytes)) or not isinstance(systems, Sequence):
+        raise ValueError("E-CS systems must be a sequence of strings")
+    if not isinstance(contracts, Mapping):
+        raise ValueError("E-CS contracts must be a mapping")
+    if system_states is not None and not isinstance(system_states, Mapping):
+        raise ValueError("E-CS system_states must be a mapping")
+    normalized = []
+    for index, system in enumerate(systems):
+        if not isinstance(system, str) or not system.strip():
+            raise ValueError(f"E-CS systems[{index}] must be a non-empty string")
+        normalized.append(system.strip())
+    normalized = tuple(normalized)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("E-CS system names must be unique within a chain")
+
+    states = system_states or {}
+    events = []
+    for index, system in enumerate(normalized, start=1):
+        configured_state = str(states.get(system, "active")).strip().lower()
+        active = configured_state in {"active", "ready", "enabled"}
+        events.append(
+            EventChainRecord(
+                event_id=_stable_event_id(chain_id, index, system),
+                chain_id=chain_id,
+                sequence=index,
+                system=system,
+                contract=str(contracts.get(system, "observe_handoff_only")),
+                predecessor=normalized[index - 2] if index > 1 else None,
+                successor=normalized[index] if index < len(normalized) else None,
+                status="planned" if active else "inactive",
+                return_value=None
+                if active
+                else {
+                    "state": "inactive",
+                    "reason": "system_not_in_use",
+                    "configured_state": configured_state or "inactive",
+                    "handled": True,
+                },
+            )
+        )
+    chain_state = "planned" if all(event.status == "planned" for event in events) else "partial"
+    return EventChain(
+        chain_id=chain_id,
+        events=tuple(events),
+        state=chain_state,
+        supervisor=supervisor,
+    )
+
+
+def bind_event_return(
+    chain: EventChain,
+    *,
+    event_id: str,
+    return_value: Mapping[str, Any],
+    status: str,
+    execute_allowed: bool,
+    mutated: bool = False,
+) -> EventChain:
+    """Return a new E-CS chain with one event result bound exactly once.
+
+    The original chain and record remain unchanged.  This is the canonical
+    return path for adapters that execute or observe work outside Cross-X.
+    """
+
+    if not isinstance(chain, EventChain):
+        raise TypeError("chain must be an EventChain")
+    event_id = normalize_ecs_identifier(event_id, field="event_id")
+    if not isinstance(return_value, Mapping):
+        raise ValueError("E-CS return_value must be a mapping")
+    normalized_status = str(status).strip().lower()
+    if normalized_status not in {"completed", "waiting", "stopped", "inactive"}:
+        raise ValueError(
+            "E-CS return status must be completed, waiting, stopped, or inactive"
+        )
+
+    matches = [index for index, event in enumerate(chain.events) if event.event_id == event_id]
+    if not matches:
+        raise ValueError(f"E-CS event_id not found in chain: {event_id}")
+    index = matches[0]
+    current = chain.events[index]
+    if current.return_value is not None and current.status != "waiting":
+        raise ValueError(f"E-CS event already has a return value: {event_id}")
+    if current.status not in {"planned", "waiting"}:
+        raise ValueError(
+            f"E-CS event status {current.status!r} cannot accept a return value"
+        )
+
+    return_history = current.return_history
+    if current.status == "waiting" and current.return_value is not None:
+        return_history = return_history + (current.return_value,)
+    updated_record = replace(
+        current,
+        status=normalized_status,
+        return_value=dict(return_value),
+        return_history=return_history,
+        execute_allowed=bool(execute_allowed),
+        mutated=bool(mutated),
+    )
+    events = chain.events[:index] + (updated_record,) + chain.events[index + 1 :]
+    statuses = {event.status for event in events}
+    if "stopped" in statuses:
+        chain_state = "stopped"
+    elif all(event.status in _TERMINAL_EVENT_STATES for event in events):
+        chain_state = "partial" if "inactive" in statuses else "completed"
+    else:
+        chain_state = "in_progress"
+    return replace(
+        chain,
+        events=events,
+        state=chain_state,
+        mutated=chain.mutated or bool(mutated),
+    )

--- a/cross_x/mpcp_adapter.py
+++ b/cross_x/mpcp_adapter.py
@@ -1,0 +1,272 @@
+"""Governed Cross -> MPCP execution adapter.
+
+Cross remains the planner/coordinator.  MPCP remains the execution structure.
+This adapter validates the handoff and explicit approval, invokes exactly one
+MPCP Modew task, and binds its return value into a new immutable E-CS chain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+from cross_x.event_chain import (
+    EventChain,
+    bind_event_return,
+    freeze_ecs_mapping,
+    normalize_ecs_identifier,
+    thaw_ecs_mapping,
+)
+
+CROSS_MPCP_ADAPTER_VERSION = "1.0"
+EXECUTION_CAPABILITY = "cross.mpcp.execute"
+MPCPExecutor = Callable[[str], Mapping[str, Any]]
+_SUCCESS_STATES = frozenset({"SUCCESS", "done", "ready"})
+_WAIT_STATES = frozenset({"WAIT", "wait", "warn", "run", "idle"})
+_STOP_STATES = frozenset({"STOP", "fail", "block"})
+
+
+def _safe_mpcp_value(value: object, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"Cross-MPCP {field} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"Cross-MPCP {field} must be non-empty")
+    if any(delimiter in normalized for delimiter in (",", ":", "\n", "\r")):
+        raise ValueError(f"Cross-MPCP {field} contains an MPCP delimiter")
+    return normalized
+
+
+@dataclass(frozen=True)
+class MPCPExecutionApproval:
+    """Human/governance approval scoped to exactly one chain event and task."""
+
+    chain_id: str
+    event_id: str
+    task: str
+    approved_by: str
+    capabilities: tuple[str, ...] = (EXECUTION_CAPABILITY,)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "chain_id",
+            normalize_ecs_identifier(self.chain_id, field="approval.chain_id"),
+        )
+        object.__setattr__(
+            self,
+            "event_id",
+            normalize_ecs_identifier(self.event_id, field="approval.event_id"),
+        )
+        object.__setattr__(
+            self,
+            "task",
+            normalize_ecs_identifier(self.task, field="approval.task"),
+        )
+        object.__setattr__(
+            self,
+            "approved_by",
+            normalize_ecs_identifier(self.approved_by, field="approval.approved_by"),
+        )
+        capabilities = tuple(
+            normalize_ecs_identifier(value, field="approval.capability")
+            for value in self.capabilities
+        )
+        if len(set(capabilities)) != len(capabilities):
+            raise ValueError("Cross-MPCP approval capabilities must be unique")
+        object.__setattr__(self, "capabilities", capabilities)
+
+
+@dataclass(frozen=True)
+class CrossMPCPResult:
+    """One governed Modew result and the new E-CS chain containing it."""
+
+    chain: EventChain
+    event_id: str
+    task: str
+    state: str
+    return_value: Mapping[str, Any]
+    executed: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "return_value",
+            freeze_ecs_mapping(self.return_value),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "adapter_version": CROSS_MPCP_ADAPTER_VERSION,
+            "event_id": self.event_id,
+            "task": self.task,
+            "state": self.state,
+            "executed": self.executed,
+            "return_value": thaw_ecs_mapping(self.return_value),
+            "event_chain": self.chain.to_dict(),
+        }
+
+
+def build_cross_mpcp_handoff(
+    cross_envelope: Mapping[str, Any],
+    *,
+    task: str,
+    context: Optional[Mapping[str, Any]] = None,
+    review_approved: bool = False,
+) -> dict[str, Any]:
+    """Normalize a Cross-Code envelope into the canonical MPCP handoff."""
+
+    if not isinstance(cross_envelope, Mapping):
+        raise ValueError("Cross-MPCP cross_envelope must be a mapping")
+    if cross_envelope.get("kind") != "cross-code-dispatch":
+        raise ValueError("Cross-MPCP requires a cross-code-dispatch envelope")
+    if cross_envelope.get("state") in {"inactive", "review"}:
+        raise ValueError("Cross-MPCP envelope is not ready for execution")
+    if cross_envelope.get("execution_allowed") is not False:
+        raise ValueError("Cross-MPCP source envelope must remain planner-only")
+    return {
+        "contract_version": CROSS_MPCP_ADAPTER_VERSION,
+        "kind": "cross-mpcp-handoff",
+        "chain_id": normalize_ecs_identifier(
+            cross_envelope.get("chain_id"),
+            field="handoff.chain_id",
+        ),
+        "event_id": normalize_ecs_identifier(
+            cross_envelope.get("event_id"),
+            field="handoff.event_id",
+        ),
+        "task": normalize_ecs_identifier(task, field="handoff.task"),
+        "context": dict(context or {}),
+        "review_approved": bool(review_approved),
+        "execution_allowed": False,
+        "mutated": False,
+    }
+
+
+def execute_cross_handoff(
+    chain: EventChain,
+    handoff: Mapping[str, Any],
+    approval: MPCPExecutionApproval,
+    *,
+    executor: Optional[MPCPExecutor] = None,
+) -> CrossMPCPResult:
+    """Execute one approved Cross handoff and immutably bind the MPCP return.
+
+    ``executor`` defaults to the repository MPCP runtime.  Dependency injection
+    remains available for tests and alternate MPCP-compatible runtimes.
+    """
+
+    if not isinstance(chain, EventChain):
+        raise TypeError("chain must be an EventChain")
+    if not isinstance(handoff, Mapping):
+        raise ValueError("Cross-MPCP handoff must be a mapping")
+
+    chain_id = normalize_ecs_identifier(
+        handoff.get("chain_id"),
+        field="handoff.chain_id",
+    )
+    event_id = normalize_ecs_identifier(
+        handoff.get("event_id"),
+        field="handoff.event_id",
+    )
+    task = normalize_ecs_identifier(
+        handoff.get("task"),
+        field="handoff.task",
+    )
+    if chain.chain_id != chain_id:
+        raise ValueError("Cross-MPCP handoff chain_id does not match EventChain")
+    if (approval.chain_id, approval.event_id, approval.task) != (
+        chain_id,
+        event_id,
+        task,
+    ):
+        raise PermissionError("Cross-MPCP approval scope does not match handoff")
+    if EXECUTION_CAPABILITY not in approval.capabilities:
+        raise PermissionError(
+            f"Cross-MPCP approval requires capability {EXECUTION_CAPABILITY}"
+        )
+
+    event = next((item for item in chain.events if item.event_id == event_id), None)
+    if event is None:
+        raise ValueError(f"Cross-MPCP event_id not found in chain: {event_id}")
+    if event.status != "planned" or event.return_value is not None:
+        raise ValueError("Cross-MPCP event is not available for execution")
+    if handoff.get("review_approved") is not True:
+        raise PermissionError("Cross-MPCP handoff must complete human review")
+    if handoff.get("execution_allowed") is True:
+        raise ValueError(
+            "Cross planner must not self-grant execution; approval grants authority"
+        )
+
+    context = handoff.get("context", {})
+    if not isinstance(context, Mapping):
+        raise ValueError("Cross-MPCP handoff context must be a mapping")
+    fields = {"TASK": task}
+    for raw_key, raw_value in context.items():
+        key = normalize_ecs_identifier(raw_key, field="handoff.context_key").upper()
+        if key == "TASK":
+            raise ValueError("Cross-MPCP context must not override TASK")
+        fields[key] = _safe_mpcp_value(raw_value, field=f"handoff.context.{key}")
+    mpcp_text = ",".join(f"{key}:{value}" for key, value in fields.items())
+
+    active_executor = executor or _default_mpcp_executor()
+    try:
+        raw_result = active_executor(mpcp_text)
+    except Exception as exc:
+        raw_result = {
+            "state": "STOP",
+            "cause": task,
+            "error": f"MPCP_EXECUTOR_ERROR:{type(exc).__name__}:{exc}",
+        }
+    if not isinstance(raw_result, Mapping):
+        raw_result = {
+            "state": "STOP",
+            "cause": task,
+            "error": "MPCP_EXECUTOR_RETURNED_NON_MAPPING",
+        }
+    result = dict(raw_result)
+    state = str(result.get("state", "STOP"))
+    event_status = _event_status_for_mpcp_state(state)
+    if event_status == "stopped" and not result.get("error"):
+        result["error"] = "MPCP_STOP_WITHOUT_ERROR"
+    return_value = {
+        "adapter_version": CROSS_MPCP_ADAPTER_VERSION,
+        "handled": True,
+        "executed": True,
+        "task": task,
+        "approved_by": approval.approved_by,
+        "state": state,
+        "mpcp": result,
+    }
+    updated_chain = bind_event_return(
+        chain,
+        event_id=event_id,
+        return_value=return_value,
+        status=event_status,
+        execute_allowed=True,
+        mutated=bool(result.get("mutated", False)),
+    )
+    return CrossMPCPResult(
+        chain=updated_chain,
+        event_id=event_id,
+        task=task,
+        state=state,
+        return_value=return_value,
+        executed=True,
+    )
+
+
+def _event_status_for_mpcp_state(state: str) -> str:
+    if state in _SUCCESS_STATES:
+        return "completed"
+    if state in _WAIT_STATES:
+        return "waiting"
+    if state in _STOP_STATES:
+        return "stopped"
+    return "stopped"
+
+
+def _default_mpcp_executor() -> MPCPExecutor:
+    from protocol.mpcp.runtime.executor import run
+
+    return run

--- a/docs/cross_mpcp_adapter.md
+++ b/docs/cross_mpcp_adapter.md
@@ -1,0 +1,122 @@
+# Cross → MPCP Adapter Standard
+
+## Purpose
+
+Cross วางแผนและรักษา trace ส่วน MPCP ควบคุมการ execute ผ่าน Modew
+adapter นี้เป็น boundary ระหว่างสองบทบาท และห้าม Cross planner ให้สิทธิ์ execute
+แก่ตัวเอง
+
+```text
+Cross-X / E-CS
+      ↓ plan
+Cross-L / Cross-Code envelope
+      ↓ normalize
+Cross-MPCP handoff
+      ↓ approval gate
+MPCP → one Modew task
+      ↓ result
+immutable E-CS return binding
+```
+
+## Required contracts
+
+### Cross envelope
+
+- `kind=cross-code-dispatch`
+- มี `chain_id` และ `event_id`
+- state ต้องพร้อม ไม่ใช่ `inactive` หรือ `review`
+- `execution_allowed` ต้องยังเป็น `false`
+
+### MPCP handoff
+
+สร้างด้วย `build_cross_mpcp_handoff(...)` และมี:
+
+- identity ตรงกับ E-CS
+- Modew `task` เพียงหนึ่งงาน
+- context ที่ไม่สามารถ override `TASK`
+- `review_approved=true` เมื่อ human/governance review เสร็จแล้ว
+- ไม่ให้ execution authority ด้วยตัวเอง
+
+### Approval
+
+`MPCPExecutionApproval` ผูกสิทธิ์กับ:
+
+- chain เดียว
+- event เดียว
+- task เดียว
+- reviewer ที่ระบุได้
+- capability `cross.mpcp.execute`
+
+approval ของ event หรืองานอื่นใช้แทนกันไม่ได้
+
+## Return contract
+
+MPCP result ถูกห่อเป็น:
+
+```json
+{
+  "adapter_version": "1.0",
+  "handled": true,
+  "executed": true,
+  "task": "verify",
+  "approved_by": "BBX19",
+  "state": "SUCCESS",
+  "mpcp": {
+    "state": "SUCCESS",
+    "cause": "verify",
+    "result": "verified"
+  }
+}
+```
+
+จากนั้น `bind_event_return(...)` จะสร้าง `EventChain` ชุดใหม่:
+
+- ไม่แก้ chain เดิม
+- terminal event รับ return ได้ครั้งเดียว
+- event สถานะ `waiting` resume ได้ โดย return เดิมจะย้ายเข้า `return_history`
+- `SUCCESS/done/ready` → `completed`
+- `WAIT/wait/warn/run/idle` → `waiting`
+- `STOP/fail/block/unknown` → `stopped`
+- chain ใดมี event `stopped` จะมี state `stopped`
+- `mutated` จะเป็นจริงเฉพาะเมื่อ MPCP result ประกาศชัดเจน
+
+## Fail-closed rules
+
+adapter ต้องไม่เรียก executor เมื่อ:
+
+- identity ไม่ตรง
+- approval scope ไม่ตรง
+- capability ขาด
+- review ยังไม่ผ่าน
+- event ไม่อยู่ในสถานะ `planned`
+- event มี return อยู่แล้ว
+- context พยายาม override `TASK`
+- context มี MPCP delimiter
+
+executor ที่คืนค่าชนิดอื่นแทน mapping หรือคืน state ที่ไม่รู้จัก จะถูกบันทึกเป็น
+`STOP` ไม่ถือเป็น success
+
+## Example
+
+```python
+from cross_x import (
+    MPCPExecutionApproval,
+    build_cross_mpcp_handoff,
+    execute_cross_handoff,
+)
+
+handoff = build_cross_mpcp_handoff(
+    cross_code_envelope,
+    task="verify",
+    context={"BOUNDARY": "read_only"},
+    review_approved=True,
+)
+approval = MPCPExecutionApproval(
+    chain_id=chain.chain_id,
+    event_id=handoff["event_id"],
+    task="verify",
+    approved_by="BBX19",
+)
+result = execute_cross_handoff(chain, handoff, approval)
+updated_chain = result.chain
+```

--- a/docs/cross_x_ecosystem.md
+++ b/docs/cross_x_ecosystem.md
@@ -10,6 +10,7 @@ ecosystem. It is not a bug hunt and not an execution authority.
 Human / Agent intent
 → Cross-X plan
 → W3Lgu five-line packet
+→ E-CS ordered handoff records
 → REDR / PSP2 / DTML process trace
 → PX position anchor
 → W3DB append envelope
@@ -39,6 +40,26 @@ Config is not source truth. It links existing truth sources and protocols.
 - EP_SIGNAL:Rytm is a reversible pulse-cadence preview, not a new truth store.
 - REDR/PSP2/DTML/LRC2 process traces are plan-only until an approved adapter persists them.
 - Human Review and Governance Gate remain required.
+- E-CS records planned subsystem handoffs; it never executes the chain itself.
+- Inactive subsystems return a handled `inactive` result instead of silently
+  disappearing from the chain or receiving a handoff.
+
+## Event-Chain System (E-CS)
+
+Cross-X materializes the configured system order as immutable E-CS records.
+Every record includes a stable event ID, sequence, subsystem contract,
+predecessor/successor, and explicit `execute_allowed: false`. The supervising
+AI may coordinate and report chain state, but it receives no truth-mutation or
+execution authority from E-CS.
+
+If a subsystem is configured as inactive, its event remains visible with
+`status: inactive` and a structured `return_value` containing
+`reason: system_not_in_use`. Other event records remain traceable, while the
+overall chain reports `state: partial`.
+
+Cross-L can bind a bounded workset to an E-CS identity through
+`dispatch_cross_code`. This produces a CrossCode handoff envelope for Modew;
+the envelope remains review-only and does not execute the declared fragment.
 
 ## Example
 

--- a/protocol/mpcp/kernel/contract.py
+++ b/protocol/mpcp/kernel/contract.py
@@ -1,6 +1,6 @@
 # mpcp/kernel/contract.py
 
-from mpcp.kernel.system import SYSTEM_NAME
+from .system import SYSTEM_NAME
 
 
 # All runtime states allowed by spec (MODEW_PAPER + MPCP_RUNTIME_SANITY_SWEEP_v2)

--- a/protocol/mpcp/runtime/executor.py
+++ b/protocol/mpcp/runtime/executor.py
@@ -1,9 +1,9 @@
 # mpcp/runtime/executor.py
 
-from mpcp.runtime.trace import trace as mpcp_trace
-from mpcp.kernel.contract import MPCPContract
-from mpcp.kernel.rot import MPCPRot
-from mpcp.kernel.system import validate_system_context
+from .trace import trace as mpcp_trace
+from ..kernel.contract import MPCPContract
+from ..kernel.rot import MPCPRot
+from ..kernel.system import validate_system_context
 
 
 # =========================

--- a/protocol/w3lgu/README.md
+++ b/protocol/w3lgu/README.md
@@ -444,15 +444,22 @@ W3Lgu คือ ภาษาที่ระบบใช้คิดกับต�
 
 ---
 
-สถานะปัจจุบัน
+## Operational Core 1.0
 
-Phase: Experimental / Living Language
+W3Lgu มี operational contract สำหรับใช้งานจริงแล้วใน
+[`operational.py`](operational.py) โดยครอบคลุม:
 
-Spec ยังไม่ตายตัว
+- 6 Rooms (`CA`, `CU`, `RE`, `SI`, `AP`, `EV`) แบบไม่บังคับลำดับ
+- PX notation `LN<ROOM>'<POSITION>` และ POC ของ Cross-X
+- 27 minimum laws ที่ตรวจสอบด้วยโค้ดได้
+- event chain `REDR → PSP2 → DTML → LRC2`
+- DTML decision `READY / REVIEW / STOP`
+- LRC2 append-only hash-linked ledger พร้อม idempotency และ verification
+- production template สำหรับระบบอื่นที่
+  [`docs/PRODUCTION_TEMPLATE.md`](docs/PRODUCTION_TEMPLATE.md)
 
-ทุกกฎต้องผ่านสนามจริง
-
-ความเรียบง่ายสำคัญกว่าความสมบูรณ์
+ตัว parser และ runtime เดิมยังคงใช้งานได้เพื่อรักษา compatibility ส่วนระบบที่
+ต้องการ operational behavior ให้ใช้ `W3LguOperationalRuntime`
 
 
 

--- a/protocol/w3lgu/__init__.py
+++ b/protocol/w3lgu/__init__.py
@@ -2,6 +2,24 @@
 
 from protocol.w3lgu.adapters import from_mapping, from_mpcp, from_text, to_mpcp
 from protocol.w3lgu.core import W3LguError, W3LguFiveLineProgram, W3LguLine, W3LguPacket, W3LguPair
+from protocol.w3lgu.encoding import decode_w3lgu_value, encode_w3lgu_value
+from protocol.w3lgu.operational import (
+    MINIMUM_LAWS,
+    ROOMS,
+    LRC2Ledger,
+    LRC2Record,
+    OperationalPackage,
+    OperationalResult,
+    OperationalStage,
+    PointOfConvergence,
+    PXPosition,
+    RoomSpec,
+    W3LguOperationalRuntime,
+    classify_room,
+    operational_template,
+    resolve_px,
+    validate_minimum_laws,
+)
 from protocol.w3lgu.parser import normalize_line, parse_five_line_program, parse_line, split_events
 from protocol.w3lgu.px import PXAnchor, append_px_to_w3db, px_from_five_line, px_to_append_envelope
 from protocol.w3lgu.runtime import W3LguRuntimeResult, run_five_line, run_line, run_packet
@@ -16,12 +34,27 @@ __all__ = [
     "W3LguPacket",
     "W3LguPair",
     "PXAnchor",
+    "PXPosition",
+    "PointOfConvergence",
+    "RoomSpec",
+    "ROOMS",
+    "MINIMUM_LAWS",
+    "LRC2Ledger",
+    "LRC2Record",
+    "OperationalPackage",
+    "OperationalResult",
+    "OperationalStage",
+    "W3LguOperationalRuntime",
     "W3LguRuntimeResult",
     "append_px_to_w3db",
+    "decode_w3lgu_value",
+    "encode_w3lgu_value",
     "from_mapping",
     "from_mpcp",
     "from_text",
     "normalize_line",
+    "classify_room",
+    "operational_template",
     "parse_five_line_program",
     "parse_line",
     "px_from_five_line",
@@ -29,9 +62,11 @@ __all__ = [
     "run_five_line",
     "run_line",
     "run_packet",
+    "resolve_px",
     "signal_for_state",
     "split_events",
     "to_mpcp",
     "validate_five_line",
     "validate_packet",
+    "validate_minimum_laws",
 ]

--- a/protocol/w3lgu/core.py
+++ b/protocol/w3lgu/core.py
@@ -8,7 +8,7 @@ separate layers.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Iterable, Literal, Mapping
 
 W3LguLineRole = Literal["MEM", "PATCH", "LAW", "EVENT", "SIGNAL"]

--- a/protocol/w3lgu/docs/PRODUCTION_TEMPLATE.md
+++ b/protocol/w3lgu/docs/PRODUCTION_TEMPLATE.md
@@ -1,0 +1,126 @@
+# W3Lgu Production Minimum Template
+
+สถานะ: **Operational contract 1.0**
+
+เอกสารนี้กำหนด “ขั้นต่ำที่นำไปใช้จริง” สำหรับระบบที่ต้องการพูดภาษา W3Lgu
+ร่วมกัน โดยไม่บังคับให้ทุกระบบมี implementation เหมือนกันทั้งหมด
+
+## หน่วยปฏิบัติการ
+
+```text
+EVENT:route,TARGET:W3DB,ROOM:EV,PX:LNEV'0007,STATE:ready,CONF:1
+```
+
+ผลที่ runtime ต้องสร้าง:
+
+```text
+REDR  -> PACKAGE + TAG + COPY(PSP2,LRC2)
+PSP2  -> STAMP + ROUTE
+DTML  -> READY | REVIEW | STOP
+LRC2  -> APPEND HASH-LINKED RECORD
+```
+
+W3Lgu ทำงานจริงในขอบเขต **อ่าน จัดประเภท ส่งต่อ ตัดสินสถานะ และบันทึก**
+แต่ไม่ถือสิทธิ์เรียก external side effect เอง การ execute ภายนอกต้องผ่าน adapter
+ที่ได้รับอนุมัติแยกต่างหาก
+
+## 6 Rooms
+
+Rooms เป็นบริบท ไม่ใช่ pipeline บังคับ จึงไม่จำเป็นต้องไหล 1 → 6
+
+| Room | Code | บริบท |
+| --- | --- | --- |
+| 1 | `CA` | Cause |
+| 2 | `CU` | Cause + Result |
+| 3 | `RE` | Result |
+| 4 | `SI` | Situation |
+| 5 | `AP` | Appearance / observed phenomenon |
+| 6 | `EV` | Event |
+
+ประกาศตรง:
+
+```text
+ROOM:CU,CAUSE:load,RESULT:slow
+```
+
+ถ้าไม่ประกาศ runtime จะจัดประเภทจาก key และเปิดเผยที่มาของการจัดประเภทใน
+`ROOM_BASIS_*` tag จึงไม่มี implicit magic
+
+## PX และ POC
+
+รูปแบบ PX ขั้นต่ำ:
+
+```text
+LNCU'0001
+```
+
+- `CU` คือ room และแกน Y (`Y=2`)
+- `0001` คือตำแหน่งบนแกน X (`X=1`)
+- จุดตัด `(X=1,Y=2)` คือ relative point
+- POC คือจุดบรรจบ Cross-X เช่น `POC'cross-01'X0001'Y0002`
+
+หาก packet ไม่มี `PX` runtime จะสร้างตำแหน่งแบบ deterministic จาก packet และ
+ติด tag `PX_DERIVED_STABLE`; replay ข้อมูลเดิมจึงได้ตำแหน่งเดิม
+
+## DTML decision
+
+| เงื่อนไข | Decision | Signal |
+| --- | --- | --- |
+| boundary clear | `READY` | `GREEN` |
+| `CONF:0.5` | `REVIEW` | `YELLOW` |
+| `!`, `STATE:STOP/BLOCK/FAIL`, `CONF:0` | `STOP` | `RED` |
+
+ทุกผลลัพธ์รวมถึง `STOP` ต้องถูก LRC2 บันทึก
+
+## LRC2 ledger
+
+- append-only
+- hash-linked จาก genesis ถึง record ล่าสุด
+- event id เดิม append ซ้ำแล้วได้ record เดิม (idempotent)
+- `verify()` ตรวจ sequence, duplicate event และ hash chain
+- เป็น in-process operational ledger; durable storage ใช้ adapter ภายนอก
+
+## 27 minimum laws
+
+โค้ดจริงอยู่ใน `MINIMUM_LAWS` และตรวจได้ด้วย `validate_minimum_laws()` กฎถูกแบ่งเป็น:
+
+1. การอ่านและไวยากรณ์
+2. ความหมายของ symbol
+3. PX / POC / 6 Rooms
+4. REDR / PSP2 / DTML / LRC2
+5. สถานะ 0.5, no implicit magic และ explicit authority
+
+ระบบอื่นนำ template ออกมาใช้ได้โดย:
+
+```python
+from protocol.w3lgu import operational_template
+
+contract = operational_template()
+```
+
+## Python runtime
+
+```python
+from protocol.w3lgu import W3LguOperationalRuntime
+
+runtime = W3LguOperationalRuntime()
+result = runtime.process_line(
+    "CAUSE:load,RESULT:slow,TARGET:QUEUE,CONF:0.5",
+    cross_id="cross-queue-01",
+)
+
+assert result.decision == "REVIEW"
+assert runtime.ledger.verify()
+```
+
+ผลลัพธ์เป็น immutable dataclass และ `to_dict()` ได้สำหรับ API, event bus,
+audit หรือ durable adapter
+
+## Input integrity
+
+- `CROSS_ID`/POC identifiers รับเฉพาะอักษร ตัวเลข `.`, `_`, `-` ความยาว
+  1–128 ตัว เพื่อไม่ให้ delimiter หรือ newline แทรก field ใหม่ในข้อความ POC
+- operational runtime ปฏิเสธ packet ที่มี key ซ้ำก่อน REDR, DTML และ LRC2
+  เพราะ packet ที่กำกวมต้องไม่ถูกตัดสินหรือบันทึกเป็นประวัติ
+- parser ระดับทั่วไปยังสามารถรายงาน duplicate เป็น warning ได้ แต่เมื่อเข้าสู่
+  operational boundary จะใช้กฎ fail-closed

--- a/protocol/w3lgu/encoding.py
+++ b/protocol/w3lgu/encoding.py
@@ -1,0 +1,20 @@
+"""Packet-safe encoding for externally supplied W3Lgu values."""
+
+from __future__ import annotations
+
+from urllib.parse import quote, unquote
+
+
+def encode_w3lgu_value(value: object) -> str:
+    """Percent-encode a value so it cannot introduce W3Lgu fields or lines."""
+
+    normalized = " ".join(
+        str(value).replace("\n", " ").replace("\r", " ").split()
+    )
+    return quote(normalized, safe="-._~")
+
+
+def decode_w3lgu_value(value: str) -> str:
+    """Decode a value previously produced by :func:`encode_w3lgu_value`."""
+
+    return unquote(value)

--- a/protocol/w3lgu/operational.py
+++ b/protocol/w3lgu/operational.py
@@ -1,0 +1,664 @@
+"""Production operational contract for W3Lgu.
+
+The original W3Lgu modules provide the compact packet grammar.  This module
+adds the minimum operational semantics shared by W3 systems:
+
+* six event rooms;
+* PX positions and a Cross-X point of convergence (POC);
+* the REDR -> PSP2 -> DTML -> LRC2 event chain;
+* an append-only, hash-linked LRC2 ledger; and
+* 27 explicit minimum laws that other systems can adopt as a template.
+
+The runtime performs real classification, routing, governance, and recording.
+It deliberately does not perform the external action described by a packet;
+that authority belongs to an explicitly approved adapter after DTML review.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping
+
+from protocol.w3lgu.core import W3LguError, W3LguPacket
+from protocol.w3lgu.parser import parse_line
+
+ROOM_CODES = ("CA", "CU", "RE", "SI", "AP", "EV")
+STAGES = ("REDR", "PSP2", "DTML", "LRC2")
+GENESIS_HASH = "0" * 64
+
+_PX_RE = re.compile(
+    r"^(?:PX\s*:\s*)?LN(?P<room>CA|CU|RE|SI|AP|EV)'(?P<position>[0-9]{4})$",
+    re.IGNORECASE,
+)
+_OPERATIONAL_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _stable_id(prefix: str, value: object, *, length: int = 20) -> str:
+    digest = hashlib.sha256(_canonical(value).encode("utf-8")).hexdigest().upper()
+    return f"{prefix}-{digest[:length]}"
+
+
+def _immutable_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(dict(value))
+
+
+def _normalize_operational_identifier(value: object, *, field: str) -> str:
+    """Return a delimiter-safe identifier for emitted operational text."""
+
+    if not isinstance(value, str):
+        raise W3LguError(f"{field} must be a string")
+    normalized = value.strip()
+    if not _OPERATIONAL_IDENTIFIER_RE.fullmatch(normalized):
+        raise W3LguError(
+            f"{field} must use 1-128 letters, digits, '.', '_' or '-'"
+        )
+    return normalized
+
+
+def _require_unique_packet_keys(packet: W3LguPacket) -> None:
+    """Reject ambiguous packets before governance or durable recording."""
+
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for pair in packet.pairs:
+        if pair.key in seen:
+            duplicates.add(pair.key)
+        seen.add(pair.key)
+    if duplicates:
+        joined = ",".join(sorted(duplicates))
+        raise W3LguError(f"Operational packet keys must be unique: {joined}")
+
+
+@dataclass(frozen=True)
+class RoomSpec:
+    """One of the six non-sequential W3Lgu event rooms."""
+
+    number: int
+    code: str
+    name: str
+    meaning: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "number": self.number,
+            "code": self.code,
+            "name": self.name,
+            "meaning": self.meaning,
+        }
+
+
+ROOMS: tuple[RoomSpec, ...] = (
+    RoomSpec(1, "CA", "CAUSE", "cause"),
+    RoomSpec(2, "CU", "CAUSE_RESULT", "cause and result"),
+    RoomSpec(3, "RE", "RESULT", "result"),
+    RoomSpec(4, "SI", "SITUATION", "situation"),
+    RoomSpec(5, "AP", "APPEARANCE", "appearance or observed phenomenon"),
+    RoomSpec(6, "EV", "EVENT", "event"),
+)
+ROOM_BY_CODE = MappingProxyType({room.code: room for room in ROOMS})
+
+
+@dataclass(frozen=True)
+class MinimumLaw:
+    """A machine-readable minimum law for W3Lgu implementations."""
+
+    number: int
+    code: str
+    statement: str
+
+
+MINIMUM_LAWS: tuple[MinimumLaw, ...] = (
+    MinimumLaw(1, "READ_LR", "Read left to right."),
+    MinimumLaw(2, "READ_UD", "Read top to bottom."),
+    MinimumLaw(3, "UPPER_DECL", "Commands, variables, and functions declare uppercase keys."),
+    MinimumLaw(4, "COLON_CONTEXT", "Colon binds one key to its context."),
+    MinimumLaw(5, "SEMICOLON_EVENT", "Semicolon separates events."),
+    MinimumLaw(6, "DOT_END", "Dot closes an event or command."),
+    MinimumLaw(7, "APOSTROPHE_SPACE", "Apostrophe separates values sharing one space."),
+    MinimumLaw(8, "COMMA_DATA", "Comma separates independent raw data in one space."),
+    MinimumLaw(9, "SLASH_RELATION", "Slash relates an activity to its context or result."),
+    MinimumLaw(10, "UNDERSCORE_INTENT", "Underscore marks requested or expected input."),
+    MinimumLaw(11, "BANG_INCOMPLETE", "Exclamation marks incomplete, harmful, or unresolved data."),
+    MinimumLaw(12, "HASH_BOUNDARY", "Hash establishes an explicit governed boundary."),
+    MinimumLaw(13, "QUOTE_HISTORY", "Quote marks a previously observed repeatable pattern."),
+    MinimumLaw(14, "TILDE_CONCURRENT", "Tilde relates concurrent activities."),
+    MinimumLaw(15, "BRACKET_AUTHORITY", "Brackets contain the authority of a local work zone."),
+    MinimumLaw(16, "PX_POSITION", "Every operational event has an explicit or derived PX position."),
+    MinimumLaw(17, "POC_CROSS_X", "POC identifies the Cross-X convergence point."),
+    MinimumLaw(18, "ROOM_NONLINEAR", "The six rooms classify context; they do not force flow order."),
+    MinimumLaw(19, "REDR_PACKAGE", "REDR classifies, tags, packages, and duplicates without rewriting truth."),
+    MinimumLaw(20, "PSP2_ROUTE", "PSP2 stamps and routes without inspecting or modifying payload truth."),
+    MinimumLaw(21, "DTML_DECIDE", "DTML reviews destination, signal, intent, and risk before authority."),
+    MinimumLaw(22, "DTML_STOP", "DTML immediately stops unresolved harmful or invalid activity."),
+    MinimumLaw(23, "LRC2_APPEND", "LRC2 appends every outcome, including failure and stop."),
+    MinimumLaw(24, "LRC2_IMMUTABLE", "LRC2 history is hash-linked and cannot be edited in place."),
+    MinimumLaw(25, "HALF_OBSERVE", "Confidence 0.5 is observable uncertainty, never final truth."),
+    MinimumLaw(26, "NO_IMPLICIT_MAGIC", "Derived meaning must be exposed in tags, room, signal, or trace."),
+    MinimumLaw(27, "EXPLICIT_AUTHORITY", "External execution requires a separate approved adapter."),
+)
+
+
+@dataclass(frozen=True)
+class PXPosition:
+    """A position in the six-room W3Lgu plane.
+
+    ``LNCU'0001`` means horizontal position 1 in room CU.  The room number is
+    the vertical coordinate, so this notation remains compact while preserving
+    an unambiguous X/Y intersection.
+    """
+
+    room: str
+    position: int
+
+    def __post_init__(self) -> None:
+        room = str(self.room).strip().upper()
+        if room not in ROOM_BY_CODE:
+            raise W3LguError(f"Unknown W3Lgu room: {self.room!r}")
+        if isinstance(self.position, bool) or not isinstance(self.position, int):
+            raise W3LguError("PX position must be an integer")
+        if not 1 <= self.position <= 9999:
+            raise W3LguError("PX position must be between 0001 and 9999")
+        object.__setattr__(self, "room", room)
+
+    @property
+    def x(self) -> int:
+        return self.position
+
+    @property
+    def y(self) -> int:
+        return ROOM_BY_CODE[self.room].number
+
+    @property
+    def relative_point(self) -> tuple[int, int]:
+        return (self.x, self.y)
+
+    def to_text(self) -> str:
+        return f"LN{self.room}'{self.position:04d}"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "px": self.to_text(),
+            "room": self.room,
+            "x": self.x,
+            "y": self.y,
+            "relative_point": [self.x, self.y],
+        }
+
+    @classmethod
+    def parse(cls, value: str) -> "PXPosition":
+        if not isinstance(value, str):
+            raise W3LguError("PX notation must be a string")
+        match = _PX_RE.fullmatch(value.strip())
+        if not match:
+            raise W3LguError("PX notation must use LN<ROOM>'<0001-9999>, for example LNCU'0001")
+        return cls(match.group("room"), int(match.group("position")))
+
+
+@dataclass(frozen=True)
+class PointOfConvergence:
+    """Cross-X convergence point shared by related W3Lgu events."""
+
+    cross_id: str
+    x: int
+    y: int
+
+    def __post_init__(self) -> None:
+        cross_id = _normalize_operational_identifier(self.cross_id, field="POC cross_id")
+        if self.x < 1 or self.y < 1:
+            raise W3LguError("POC coordinates must be positive")
+        object.__setattr__(self, "cross_id", cross_id)
+
+    def to_text(self) -> str:
+        return f"POC'{self.cross_id}'X{self.x:04d}'Y{self.y:04d}"
+
+
+@dataclass(frozen=True)
+class OperationalPackage:
+    """Immutable REDR package passed by reference through the event chain."""
+
+    package_id: str
+    packet: W3LguPacket
+    room: RoomSpec
+    px: PXPosition
+    poc: PointOfConvergence
+    tags: tuple[str, ...]
+    duplicate_to: tuple[str, ...] = ("PSP2", "LRC2")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "package_id": self.package_id,
+            "packet": self.packet.to_dict(),
+            "room": self.room.to_dict(),
+            "px": self.px.to_dict(),
+            "poc": self.poc.to_text(),
+            "tags": list(self.tags),
+            "duplicate_to": list(self.duplicate_to),
+        }
+
+
+@dataclass(frozen=True)
+class OperationalStage:
+    """One auditable stage transition."""
+
+    stage: str
+    status: str
+    action: str
+    data: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        stage = str(self.stage).strip().upper()
+        if stage not in STAGES:
+            raise W3LguError(f"Unknown operational stage: {self.stage!r}")
+        object.__setattr__(self, "stage", stage)
+        object.__setattr__(self, "data", _immutable_mapping(self.data))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stage": self.stage,
+            "status": self.status,
+            "action": self.action,
+            "data": dict(self.data),
+        }
+
+
+@dataclass(frozen=True)
+class LRC2Record:
+    """One append-only, hash-linked history record."""
+
+    sequence: int
+    record_id: str
+    timestamp: str
+    event_id: str
+    package_id: str
+    stage: str
+    status: str
+    payload: Mapping[str, Any]
+    previous_hash: str
+    record_hash: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "payload", _immutable_mapping(self.payload))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "sequence": self.sequence,
+            "record_id": self.record_id,
+            "timestamp": self.timestamp,
+            "event_id": self.event_id,
+            "package_id": self.package_id,
+            "stage": self.stage,
+            "status": self.status,
+            "payload": dict(self.payload),
+            "previous_hash": self.previous_hash,
+            "record_hash": self.record_hash,
+        }
+
+
+class LRC2Ledger:
+    """Thread-safe append-only ledger with idempotent event recording."""
+
+    def __init__(self) -> None:
+        self._records: list[LRC2Record] = []
+        self._event_index: dict[str, LRC2Record] = {}
+        self._lock = threading.RLock()
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._records)
+
+    def records(self) -> tuple[LRC2Record, ...]:
+        with self._lock:
+            return tuple(self._records)
+
+    def append(
+        self,
+        *,
+        event_id: str,
+        package_id: str,
+        stage: str,
+        status: str,
+        payload: Mapping[str, Any],
+        timestamp: str | None = None,
+    ) -> LRC2Record:
+        event_id = str(event_id).strip()
+        if not event_id:
+            raise W3LguError("LRC2 event_id must be non-empty")
+        with self._lock:
+            existing = self._event_index.get(event_id)
+            if existing is not None:
+                return existing
+            sequence = len(self._records) + 1
+            previous_hash = self._records[-1].record_hash if self._records else GENESIS_HASH
+            body = {
+                "sequence": sequence,
+                "event_id": event_id,
+                "package_id": package_id,
+                "stage": stage,
+                "status": status,
+                "payload": dict(payload),
+                "previous_hash": previous_hash,
+            }
+            record_hash = hashlib.sha256(_canonical(body).encode("utf-8")).hexdigest()
+            record = LRC2Record(
+                sequence=sequence,
+                record_id=f"LRC2-{record_hash[:20].upper()}",
+                timestamp=timestamp or _now_iso(),
+                event_id=event_id,
+                package_id=package_id,
+                stage=stage,
+                status=status,
+                payload=payload,
+                previous_hash=previous_hash,
+                record_hash=record_hash,
+            )
+            self._records.append(record)
+            self._event_index[event_id] = record
+            return record
+
+    def verify(self) -> bool:
+        with self._lock:
+            previous_hash = GENESIS_HASH
+            seen: set[str] = set()
+            for expected_sequence, record in enumerate(self._records, start=1):
+                if record.sequence != expected_sequence or record.event_id in seen:
+                    return False
+                body = {
+                    "sequence": record.sequence,
+                    "event_id": record.event_id,
+                    "package_id": record.package_id,
+                    "stage": record.stage,
+                    "status": record.status,
+                    "payload": dict(record.payload),
+                    "previous_hash": previous_hash,
+                }
+                expected_hash = hashlib.sha256(_canonical(body).encode("utf-8")).hexdigest()
+                if record.previous_hash != previous_hash or record.record_hash != expected_hash:
+                    return False
+                seen.add(record.event_id)
+                previous_hash = record.record_hash
+            return True
+
+
+@dataclass(frozen=True)
+class OperationalResult:
+    """Complete result of one W3Lgu operational event."""
+
+    event_id: str
+    package: OperationalPackage
+    stages: tuple[OperationalStage, ...]
+    decision: str
+    signal: str
+    execute_allowed: bool
+    lrc2_records: tuple[LRC2Record, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "event_id": self.event_id,
+            "package": self.package.to_dict(),
+            "stages": [stage.to_dict() for stage in self.stages],
+            "decision": self.decision,
+            "signal": self.signal,
+            "execute_allowed": self.execute_allowed,
+            "lrc2_records": [record.to_dict() for record in self.lrc2_records],
+        }
+
+
+class W3LguOperationalRuntime:
+    """Operational W3Lgu engine with explicit policy and an LRC2 ledger."""
+
+    def __init__(self, *, ledger: LRC2Ledger | None = None) -> None:
+        self.ledger = ledger if ledger is not None else LRC2Ledger()
+
+    def process_line(
+        self,
+        text: str,
+        *,
+        cross_id: str | None = None,
+        timestamp: str | None = None,
+    ) -> OperationalResult:
+        return self.process_packet(parse_line(text), cross_id=cross_id, timestamp=timestamp)
+
+    def process_packet(
+        self,
+        packet: W3LguPacket,
+        *,
+        cross_id: str | None = None,
+        timestamp: str | None = None,
+    ) -> OperationalResult:
+        _require_unique_packet_keys(packet)
+        room, room_basis = classify_room(packet)
+        px, px_basis = resolve_px(packet, room)
+        supplied_cross_id = cross_id if cross_id is not None else packet.get("CROSS_ID")
+        if supplied_cross_id is None:
+            resolved_cross_id = _stable_id("CROSS", packet.to_dict(), length=16)
+        else:
+            resolved_cross_id = _normalize_operational_identifier(
+                supplied_cross_id,
+                field="POC cross_id",
+            )
+        poc = PointOfConvergence(resolved_cross_id, px.x, px.y)
+        tags = _derive_tags(packet, room, room_basis, px_basis)
+        package_body = {
+            "packet": packet.to_dict(),
+            "room": room.code,
+            "px": px.to_text(),
+            "poc": poc.to_text(),
+            "tags": tags,
+        }
+        package = OperationalPackage(
+            package_id=_stable_id("PKG", package_body),
+            packet=packet,
+            room=room,
+            px=px,
+            poc=poc,
+            tags=tags,
+        )
+        event_id = _stable_id("EVT", {"package": package.package_id, "cross": resolved_cross_id})
+
+        redr = OperationalStage(
+            "REDR",
+            "PACKAGED",
+            "READ_CLASSIFY_TAG_DUPLICATE",
+            {
+                "room": room.code,
+                "room_basis": room_basis,
+                "tags": tags,
+                "duplicate_to": package.duplicate_to,
+            },
+        )
+        target = str(packet.get("TARGET") or room.code).strip().upper()
+        psp2 = OperationalStage(
+            "PSP2",
+            "ROUTED",
+            "STAMP_ROUTE_ONLY",
+            {
+                "stamp": f"PSP2'{event_id}",
+                "route": ("W3LGU", px.to_text(), target, "LRC2"),
+                "payload_changed": False,
+            },
+        )
+        decision, signal, reasons = _dtml_decision(packet, target)
+        dtml = OperationalStage(
+            "DTML",
+            decision,
+            "INSPECT_DESTINATION_SIGNAL_INTENT",
+            {
+                "target": target,
+                "signal": signal,
+                "reasons": reasons,
+                "external_authority": False,
+            },
+        )
+        lrc2 = OperationalStage(
+            "LRC2",
+            "RECORDED",
+            "APPEND_HASH_LINKED_HISTORY",
+            {
+                "event_id": event_id,
+                "decision": decision,
+                "record_count": len(STAGES),
+            },
+        )
+        stages = (redr, psp2, dtml, lrc2)
+        records = tuple(
+            self.ledger.append(
+                event_id=f"{event_id}:{stage.stage}",
+                package_id=package.package_id,
+                stage=stage.stage,
+                status=stage.status,
+                payload=stage.to_dict(),
+                timestamp=timestamp,
+            )
+            for stage in stages
+        )
+        return OperationalResult(
+            event_id=event_id,
+            package=package,
+            stages=stages,
+            decision=decision,
+            signal=signal,
+            execute_allowed=False,
+            lrc2_records=records,
+        )
+
+
+def classify_room(packet: W3LguPacket) -> tuple[RoomSpec, str]:
+    """Classify an event room using explicit fields before deterministic hints."""
+
+    explicit = packet.get("ROOM") or packet.get("TYPE")
+    if explicit:
+        code = str(explicit).strip().upper()
+        if code.startswith("ROOM") and code[4:].isdigit():
+            number = int(code[4:])
+            if 1 <= number <= len(ROOMS):
+                return ROOMS[number - 1], "explicit_number"
+        if code in ROOM_BY_CODE:
+            return ROOM_BY_CODE[code], "explicit_code"
+        raise W3LguError(f"Unknown W3Lgu room declaration: {explicit!r}")
+
+    keys = set(packet.to_dict())
+    if {"CAUSE", "RESULT"} <= keys:
+        return ROOM_BY_CODE["CU"], "keys:CAUSE+RESULT"
+    hints = (
+        ("CA", {"CAUSE"}),
+        ("RE", {"RESULT", "OUTCOME"}),
+        ("SI", {"SITUATION", "CONTEXT"}),
+        ("AP", {"APPEARANCE", "OBSERVED", "PHENOMENON"}),
+        ("EV", {"EVENT", "TASK", "ACTION"}),
+    )
+    for code, candidates in hints:
+        matched = keys & candidates
+        if matched:
+            return ROOM_BY_CODE[code], f"keys:{'+'.join(sorted(matched))}"
+    return ROOM_BY_CODE["EV"], "default_event"
+
+
+def resolve_px(packet: W3LguPacket, room: RoomSpec) -> tuple[PXPosition, str]:
+    explicit = packet.get("PX")
+    if explicit:
+        px = PXPosition.parse(str(explicit))
+        if px.room != room.code:
+            raise W3LguError(
+                f"PX room {px.room} conflicts with classified room {room.code}"
+            )
+        return px, "explicit"
+    digest = hashlib.sha256(_canonical(packet.to_dict()).encode("utf-8")).digest()
+    position = int.from_bytes(digest[:2], "big") % 9999 + 1
+    return PXPosition(room.code, position), "derived_stable"
+
+
+def operational_template() -> dict[str, object]:
+    """Return the minimum contract other W3 systems can adopt."""
+
+    return {
+        "version": "1.0",
+        "rooms": [room.to_dict() for room in ROOMS],
+        "stages": list(STAGES),
+        "laws": [
+            {"number": law.number, "code": law.code, "statement": law.statement}
+            for law in MINIMUM_LAWS
+        ],
+        "px_example": PXPosition("CU", 1).to_text(),
+        "poc": "Cross-X",
+        "external_execution": "approved_adapter_only",
+    }
+
+
+def _derive_tags(
+    packet: W3LguPacket,
+    room: RoomSpec,
+    room_basis: str,
+    px_basis: str,
+) -> tuple[str, ...]:
+    tags = {
+        f"ROOM_{room.code}",
+        f"ROOM_BASIS_{room_basis.upper().replace(':', '_').replace('+', '_')}",
+        f"PX_{px_basis.upper()}",
+    }
+    source = packet.source
+    if "!" in source:
+        tags.add("UNRESOLVED")
+    if "#" in source:
+        tags.add("GOVERNED_BOUNDARY")
+    if "~" in source:
+        tags.add("CONCURRENT")
+    if '"' in source:
+        tags.add("KNOWN_PATTERN")
+    return tuple(sorted(tags))
+
+
+def _dtml_decision(packet: W3LguPacket, target: str) -> tuple[str, str, tuple[str, ...]]:
+    reasons: list[str] = []
+    state = str(packet.get("STATE") or "").strip().upper()
+    confidence = _parse_confidence(packet.get("CONF"))
+    source = packet.source
+
+    if not target:
+        reasons.append("TARGET_MISSING")
+    if "!" in source:
+        reasons.append("UNRESOLVED_OR_HARMFUL_MARKER")
+    if state in {"STOP", "BLOCK", "FAIL"}:
+        reasons.append(f"STATE_{state}")
+    if confidence is not None and confidence <= 0:
+        reasons.append("CONFIDENCE_ZERO")
+
+    if reasons:
+        return "STOP", "RED", tuple(reasons)
+    if confidence == 0.5:
+        return "REVIEW", "YELLOW", ("CONFIDENCE_HALF",)
+    return "READY", "GREEN", ("BOUNDARY_CLEAR",)
+
+
+def _parse_confidence(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError) as exc:
+        raise W3LguError(f"CONF must be numeric, got {value!r}") from exc
+    if not 0 <= confidence <= 1:
+        raise W3LguError("CONF must be between 0 and 1")
+    return confidence
+
+
+def validate_minimum_laws(laws: Iterable[MinimumLaw] = MINIMUM_LAWS) -> bool:
+    values = tuple(laws)
+    return (
+        len(values) == 27
+        and tuple(law.number for law in values) == tuple(range(1, 28))
+        and len({law.code for law in values}) == 27
+    )

--- a/tests/test_cross_mpcp_adapter.py
+++ b/tests/test_cross_mpcp_adapter.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from cross_x import (
+    EXECUTION_CAPABILITY,
+    MPCPExecutionApproval,
+    bind_event_return,
+    build_cross_mpcp_handoff,
+    build_event_chain,
+    execute_cross_handoff,
+)
+
+
+def _chain():
+    return build_event_chain(
+        chain_id="cross-mpcp-test",
+        systems=("CrossCode",),
+        contracts={"CrossCode": "approved_modew_execution"},
+    )
+
+
+def _cross_envelope(event_id: str):
+    return {
+        "contract_version": "1.0",
+        "kind": "cross-code-dispatch",
+        "chain_id": "cross-mpcp-test",
+        "event_id": event_id,
+        "state": "planned",
+        "execution_allowed": False,
+        "mutated": False,
+    }
+
+
+def _approval(event_id: str, *, task: str = "verify"):
+    return MPCPExecutionApproval(
+        chain_id="cross-mpcp-test",
+        event_id=event_id,
+        task=task,
+        approved_by="BBX19",
+    )
+
+
+def test_cross_mpcp_executes_one_modew_and_binds_return_immutably():
+    chain = _chain()
+    event = chain.events[0]
+    handoff = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        context={"BOUNDARY": "read_only", "PX": "LNEV'0001"},
+        review_approved=True,
+    )
+    calls = []
+
+    def executor(text):
+        calls.append(text)
+        return {
+            "state": "SUCCESS",
+            "cause": "verify",
+            "result": "verified",
+            "mutated": False,
+        }
+
+    result = execute_cross_handoff(
+        chain,
+        handoff,
+        _approval(event.event_id),
+        executor=executor,
+    )
+
+    assert calls == ["TASK:verify,BOUNDARY:read_only,PX:LNEV'0001"]
+    assert chain.state == "planned"
+    assert chain.events[0].return_value is None
+    assert result.executed is True
+    assert result.state == "SUCCESS"
+    assert result.chain is not chain
+    assert result.chain.state == "completed"
+    returned = result.chain.events[0]
+    assert returned.status == "completed"
+    assert returned.execute_allowed is True
+    assert returned.mutated is False
+    assert returned.return_value["handled"] is True
+    assert returned.return_value["approved_by"] == "BBX19"
+    assert returned.return_value["mpcp"]["result"] == "verified"
+
+
+def test_cross_mpcp_rejects_unreviewed_handoff_without_calling_executor():
+    chain = _chain()
+    event = chain.events[0]
+    handoff = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        review_approved=False,
+    )
+    calls = []
+
+    with pytest.raises(PermissionError, match="human review"):
+        execute_cross_handoff(
+            chain,
+            handoff,
+            _approval(event.event_id),
+            executor=lambda text: calls.append(text),
+        )
+
+    assert calls == []
+    assert chain.events[0].return_value is None
+
+
+def test_cross_mpcp_approval_is_scoped_to_chain_event_task_and_capability():
+    chain = _chain()
+    event = chain.events[0]
+    handoff = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        review_approved=True,
+    )
+
+    with pytest.raises(PermissionError, match="scope"):
+        execute_cross_handoff(
+            chain,
+            handoff,
+            _approval(event.event_id, task="apply"),
+            executor=lambda text: {"state": "SUCCESS", "cause": "verify"},
+        )
+    approval_without_capability = MPCPExecutionApproval(
+        chain_id=chain.chain_id,
+        event_id=event.event_id,
+        task="verify",
+        approved_by="BBX19",
+        capabilities=(),
+    )
+    with pytest.raises(PermissionError, match=EXECUTION_CAPABILITY):
+        execute_cross_handoff(
+            chain,
+            handoff,
+            approval_without_capability,
+            executor=lambda text: {"state": "SUCCESS", "cause": "verify"},
+        )
+
+
+def test_cross_mpcp_stop_result_stops_chain_and_preserves_error():
+    chain = _chain()
+    event = chain.events[0]
+    handoff = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        review_approved=True,
+    )
+
+    result = execute_cross_handoff(
+        chain,
+        handoff,
+        _approval(event.event_id),
+        executor=lambda text: {
+            "state": "STOP",
+            "cause": "verify",
+            "error": "BOUNDARY_DENIED",
+        },
+    )
+
+    assert result.chain.state == "stopped"
+    assert result.chain.events[0].status == "stopped"
+    assert result.return_value["mpcp"]["error"] == "BOUNDARY_DENIED"
+
+
+def test_cross_mpcp_non_mapping_or_unknown_result_fails_closed():
+    chain = _chain()
+    event = chain.events[0]
+    handoff = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        review_approved=True,
+    )
+
+    result = execute_cross_handoff(
+        chain,
+        handoff,
+        _approval(event.event_id),
+        executor=lambda text: "bad result",
+    )
+
+    assert result.state == "STOP"
+    assert result.chain.state == "stopped"
+    assert (
+        result.return_value["mpcp"]["error"]
+        == "MPCP_EXECUTOR_RETURNED_NON_MAPPING"
+    )
+
+
+def test_cross_mpcp_executor_exception_is_bound_as_stop_return():
+    chain = _chain()
+    event = chain.events[0]
+    handoff = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        review_approved=True,
+    )
+
+    def broken_executor(text):
+        raise RuntimeError("worker unavailable")
+
+    result = execute_cross_handoff(
+        chain,
+        handoff,
+        _approval(event.event_id),
+        executor=broken_executor,
+    )
+
+    assert result.state == "STOP"
+    assert result.chain.state == "stopped"
+    assert result.return_value["mpcp"]["error"].startswith(
+        "MPCP_EXECUTOR_ERROR:RuntimeError"
+    )
+
+
+def test_event_return_can_only_be_bound_once():
+    chain = _chain()
+    event = chain.events[0]
+    updated = bind_event_return(
+        chain,
+        event_id=event.event_id,
+        return_value={"state": "SUCCESS"},
+        status="completed",
+        execute_allowed=True,
+    )
+
+    with pytest.raises(ValueError, match="already has a return"):
+        bind_event_return(
+            updated,
+            event_id=event.event_id,
+            return_value={"state": "SUCCESS"},
+            status="completed",
+            execute_allowed=True,
+        )
+    with pytest.raises(TypeError):
+        updated.events[0].return_value["state"] = "STOP"  # type: ignore[index]
+    nested = bind_event_return(
+        _chain(),
+        event_id=_chain().events[0].event_id,
+        return_value={"mpcp": {"state": "SUCCESS", "trace": ["A", "B"]}},
+        status="completed",
+        execute_allowed=True,
+    )
+    with pytest.raises(TypeError):
+        nested.events[0].return_value["mpcp"]["state"] = "STOP"  # type: ignore[index]
+    assert nested.to_dict()["events"][0]["return_value"]["mpcp"]["trace"] == [
+        "A",
+        "B",
+    ]
+    with pytest.raises(FrozenInstanceError):
+        updated.state = "stopped"  # type: ignore[misc]
+
+
+def test_waiting_event_can_resume_without_losing_return_history():
+    chain = _chain()
+    event = chain.events[0]
+    waiting = bind_event_return(
+        chain,
+        event_id=event.event_id,
+        return_value={"state": "WAIT", "reason": "dependency"},
+        status="waiting",
+        execute_allowed=True,
+    )
+    completed = bind_event_return(
+        waiting,
+        event_id=event.event_id,
+        return_value={"state": "SUCCESS", "result": "resumed"},
+        status="completed",
+        execute_allowed=True,
+    )
+
+    record = completed.events[0]
+    assert completed.state == "completed"
+    assert record.return_value["state"] == "SUCCESS"
+    assert record.return_history[0]["state"] == "WAIT"
+    assert completed.to_dict()["events"][0]["return_history"] == [
+        {"state": "WAIT", "reason": "dependency"}
+    ]
+
+
+def test_cross_mpcp_context_cannot_override_task_or_inject_delimiters():
+    chain = _chain()
+    event = chain.events[0]
+    approval = _approval(event.event_id)
+
+    task_override = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        context={"TASK": "apply"},
+        review_approved=True,
+    )
+    with pytest.raises(ValueError, match="override TASK"):
+        execute_cross_handoff(
+            chain,
+            task_override,
+            approval,
+            executor=lambda text: {"state": "SUCCESS"},
+        )
+
+    injection = build_cross_mpcp_handoff(
+        _cross_envelope(event.event_id),
+        task="verify",
+        context={"BOUNDARY": "safe,MODE:execute"},
+        review_approved=True,
+    )
+    with pytest.raises(ValueError, match="delimiter"):
+        execute_cross_handoff(
+            chain,
+            injection,
+            approval,
+            executor=lambda text: {"state": "SUCCESS"},
+        )

--- a/tests/test_cross_x_config.py
+++ b/tests/test_cross_x_config.py
@@ -2,8 +2,9 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from config import load_w3_config, validate_w3_config
-from cross_x import CrossXRequest, build_cross_x_plan
+from config import W3ConfigBundle, load_w3_config, validate_w3_config
+from cross_x import CrossXRequest, audit_cross_systems, build_cross_x_plan, build_event_chain
+from protocol.w3lgu import decode_w3lgu_value
 
 
 def test_w3_config_bundle_covers_current_ecosystem():
@@ -38,7 +39,20 @@ def test_cross_x_plan_builds_full_non_mutating_chain():
     assert body["governance"]["human_review_required"] is True
     assert body["governance"]["truth_mutation_allowed"] is False
     assert body["chain"] == ["W3-API", "W3Lgu", "REDR", "PSP2", "DTML", "PX", "W3DB_APPEND", "EP_SIGNAL", "EP_SIGNAL_RYTM", "LRC2", "Hospitication", "IGET"]
+    event_chain = body["event_chain"]
+    assert event_chain["chain_id"] == "cross-test"
+    assert event_chain["supervisor"] == "AI_SUPERVISOR"
+    assert event_chain["mutated"] is False
+    assert [event["system"] for event in event_chain["events"]] == body["chain"]
+    assert [event["sequence"] for event in event_chain["events"]] == list(range(1, 13))
+    assert event_chain["events"][0]["predecessor"] is None
+    assert event_chain["events"][-1]["successor"] is None
+    assert all(event["execute_allowed"] is False for event in event_chain["events"])
+    assert event_chain["events"][1]["contract"] == "five_line_packet_contract"
     assert body["w3lgu"].splitlines()[0].startswith("MEM:")
+    assert "CHAIN_ID:cross-test" in body["w3lgu"].splitlines()[0]
+    assert "ECS_STATE:planned" in body["w3lgu"].splitlines()[3]
+    assert "EXECUTE_ALLOWED:false" in body["w3lgu"].splitlines()[4]
     assert body["px"]["relation"] == "cross_x.workflow_improvement"
     assert body["append_envelope"]["kind"] == "PX"
     assert body["ep_signal"]["mode"] == "preview_only"
@@ -47,6 +61,9 @@ def test_cross_x_plan_builds_full_non_mutating_chain():
     assert body["ep_signal"]["rytm"]["rytm_signal"].endswith("//BIN.")
     assert [stage["stage"] for stage in body["process_trace"]["stages"]] == ["REDR", "PSP2", "DTML", "LRC2"]
     assert body["process_trace"]["mutated"] is False
+    assert body["system_audit"]["status"] == "ready"
+    assert body["system_audit"]["checked"] == len(body["chain"])
+    assert body["system_audit"]["issues"] == []
 
 
 def test_cross_x_rejects_unsupported_modes():
@@ -54,8 +71,186 @@ def test_cross_x_rejects_unsupported_modes():
         build_cross_x_plan(source="BBX19", intent="execute directly", mode="execute")
 
 
+@pytest.mark.parametrize(
+    "cross_id",
+    (
+        "foo,CHAIN_ID:evil",
+        "foo\nCHAIN_ID:evil",
+        "",
+    ),
+)
+def test_cross_x_rejects_w3lgu_unsafe_cross_ids(cross_id):
+    with pytest.raises(ValueError, match="chain_id"):
+        build_cross_x_plan(source="Codex", intent="trace", cross_id=cross_id)
+
+
+def test_cross_x_encodes_untrusted_w3lgu_values_without_field_injection():
+    plan = build_cross_x_plan(
+        source="Codex,CHAIN_ID:evil",
+        intent="review,EXECUTE_ALLOWED:true\nSTATE:run",
+        target="W3DB,CONTRACT:overwrite",
+        mode="cross",
+        payload={"contract": "observe,MODE:execute"},
+        cross_id="safe-chain",
+    )
+
+    assert plan.program.memory.get("CHAIN_ID") == "safe-chain"
+    assert plan.program.memory.get("EVIL") is None
+    assert plan.program.event.get("EXECUTE_ALLOWED") is None
+    assert plan.program.event.get("STATE") is None
+    assert plan.program.law.get("MODE") is None
+    assert decode_w3lgu_value(plan.program.memory.get("SOURCE") or "") == (
+        "Codex,CHAIN_ID:evil"
+    )
+    assert decode_w3lgu_value(plan.program.event.get("INTENT") or "") == (
+        "review,EXECUTE_ALLOWED:true STATE:run"
+    )
+
+
 def test_cross_x_request_is_immutable():
     request = CrossXRequest(source="Codex", intent="plan", target="PX")
 
     with pytest.raises(FrozenInstanceError):
         request.source = "mutated"  # type: ignore[misc]
+
+
+def test_event_chain_rejects_duplicate_system_handoffs():
+    with pytest.raises(ValueError, match="unique"):
+        build_event_chain(
+            chain_id="duplicate",
+            systems=("W3Lgu", "W3Lgu"),
+            contracts={"W3Lgu": "five_line_packet_contract"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    (
+        ({"systems": "W3Lgu"}, "systems"),
+        ({"systems": ({"bad": "entry"},)}, r"systems\[0\]"),
+        ({"contracts": []}, "contracts"),
+        ({"system_states": []}, "system_states"),
+    ),
+)
+def test_event_chain_rejects_malformed_public_inputs(kwargs, expected):
+    values = {
+        "chain_id": "safe",
+        "systems": ("W3Lgu",),
+        "contracts": {"W3Lgu": "five_line_packet_contract"},
+    }
+    values.update(kwargs)
+
+    with pytest.raises(ValueError, match=expected):
+        build_event_chain(**values)
+
+
+def test_event_chain_normalizes_safe_ids_and_supervisor():
+    chain = build_event_chain(
+        chain_id="  cross-safe  ",
+        systems=("W3Lgu",),
+        contracts={"W3Lgu": "five_line_packet_contract"},
+        supervisor="  CODEX_SUPERVISOR  ",
+    )
+
+    assert chain.chain_id == "cross-safe"
+    assert chain.supervisor == "CODEX_SUPERVISOR"
+
+
+@pytest.mark.parametrize("supervisor", ("", " bad value ", "AI,MODE:execute"))
+def test_event_chain_rejects_unsafe_supervisor(supervisor):
+    with pytest.raises(ValueError, match="supervisor"):
+        build_event_chain(
+            chain_id="safe",
+            systems=("W3Lgu",),
+            contracts={"W3Lgu": "five_line_packet_contract"},
+            supervisor=supervisor,
+        )
+
+
+def test_event_chain_returns_value_when_system_is_inactive():
+    chain = build_event_chain(
+        chain_id="inactive-test",
+        systems=("W3Lgu", "PX"),
+        contracts={
+            "W3Lgu": "five_line_packet_contract",
+            "PX": "position_pointer_not_execution",
+        },
+        system_states={"W3Lgu": "active", "PX": "inactive"},
+    )
+
+    body = chain.to_dict()
+    assert body["state"] == "partial"
+    assert body["events"][0]["status"] == "planned"
+    assert body["events"][0]["return_value"] is None
+    assert body["events"][1]["status"] == "inactive"
+    assert body["events"][1]["return_value"] == {
+        "state": "inactive",
+        "reason": "system_not_in_use",
+        "configured_state": "inactive",
+        "handled": True,
+    }
+
+
+def test_cross_system_audit_reports_all_current_chain_members_ready():
+    report = audit_cross_systems(load_w3_config())
+
+    assert report["status"] == "ready"
+    assert report["checked"] == 12
+    assert report["issues"] == []
+    assert all(system["path_exists"] for system in report["systems"])
+
+
+@pytest.mark.parametrize(
+    ("chain", "contracts", "expected"),
+    (
+        ([{"bad": "entry"}], {}, "chain[0]"),
+        ([""], {}, "chain[0]"),
+        (["W3Lgu"], [], "contracts must be an object"),
+    ),
+)
+def test_config_validation_reports_malformed_chain_without_crashing(
+    chain, contracts, expected
+):
+    config = load_w3_config()
+    malformed_cross = dict(config.cross_system)
+    malformed_cross["chain"] = chain
+    malformed_cross["contracts"] = contracts
+    malformed = W3ConfigBundle(
+        environment=config.environment,
+        ecosystem=config.ecosystem,
+        cross_system=malformed_cross,
+        paths=config.paths,
+    )
+
+    errors = validate_w3_config(malformed)
+
+    assert any(expected in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "supervisor",
+    (
+        "AI SUPERVISOR",
+        "AI_SUPERVISOR,CHAIN_ID:override",
+        "AI\nSUPERVISOR",
+        "A" * 129,
+    ),
+)
+def test_config_validation_rejects_unsafe_event_chain_supervisor(supervisor):
+    config = load_w3_config()
+    malformed_cross = dict(config.cross_system)
+    malformed_cross_x = dict(malformed_cross["cross_x"])
+    malformed_cross_x["event_chain_supervisor"] = supervisor
+    malformed_cross["cross_x"] = malformed_cross_x
+    malformed = W3ConfigBundle(
+        environment=config.environment,
+        ecosystem=config.ecosystem,
+        cross_system=malformed_cross,
+        paths=config.paths,
+    )
+
+    errors = validate_w3_config(malformed)
+
+    assert any(
+        "event_chain_supervisor must use 1-128" in error for error in errors
+    )

--- a/tests/test_w3_api_cross.py
+++ b/tests/test_w3_api_cross.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from src.w3db.store import W3DBStore
+from protocol.w3lgu import decode_w3lgu_value, parse_five_line_program
 from w3_api.main import app
 
 client = TestClient(app)
@@ -85,3 +86,25 @@ def test_w3_cross_rejects_empty_intent():
     response = client.post("/w3/cross", json={"source": "BBX19", "intent": ""})
 
     assert response.status_code == 422
+
+
+def test_w3_cross_encodes_packet_delimiters_from_external_input():
+    response = client.post(
+        "/w3/cross",
+        json={
+            "source": "Agent,MODE:execute",
+            "intent": "observe,STATE:run\nTASK:overwrite",
+            "target": "W3DB,CONTRACT:overwrite",
+            "payload": {"contract": "observe,MODE:execute"},
+        },
+    )
+
+    assert response.status_code == 200
+    program = parse_five_line_program(response.json()["w3lgu"])
+    assert program.memory.get("MODE") is None
+    assert program.event.get("STATE") is None
+    assert program.event.get("TASK") is None
+    assert program.law.get("MODE") is None
+    assert decode_w3lgu_value(program.memory.get("SOURCE") or "") == (
+        "Agent,MODE:execute"
+    )

--- a/tests/test_w3lgu_operational.py
+++ b/tests/test_w3lgu_operational.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from protocol.w3lgu import (
+    MINIMUM_LAWS,
+    LRC2Ledger,
+    PointOfConvergence,
+    PXPosition,
+    W3LguError,
+    W3LguPacket,
+    W3LguPair,
+    W3LguOperationalRuntime,
+    operational_template,
+    parse_line,
+    validate_minimum_laws,
+)
+
+
+def test_production_template_exposes_exactly_27_numbered_laws_and_six_rooms():
+    template = operational_template()
+
+    assert validate_minimum_laws()
+    assert len(MINIMUM_LAWS) == 27
+    assert [law["number"] for law in template["laws"]] == list(range(1, 28))
+    assert [room["code"] for room in template["rooms"]] == ["CA", "CU", "RE", "SI", "AP", "EV"]
+    assert template["px_example"] == "LNCU'0001"
+    assert template["poc"] == "Cross-X"
+
+
+def test_px_notation_maps_horizontal_position_and_room_vertical_axis():
+    px = PXPosition.parse("PX:LNCU'0001")
+
+    assert px.room == "CU"
+    assert px.x == 1
+    assert px.y == 2
+    assert px.relative_point == (1, 2)
+    assert px.to_text() == "LNCU'0001"
+
+
+@pytest.mark.parametrize(
+    ("line", "expected_room"),
+    (
+        ("CAUSE:rain,ROOM:CA", "CA"),
+        ("CAUSE:rain,RESULT:flood", "CU"),
+        ("RESULT:stable", "RE"),
+        ("SITUATION:offline", "SI"),
+        ("APPEARANCE:latency", "AP"),
+        ("EVENT:sync", "EV"),
+    ),
+)
+def test_operational_runtime_classifies_all_six_rooms(line: str, expected_room: str):
+    result = W3LguOperationalRuntime().process_line(line, cross_id="cross-room-test")
+
+    assert result.package.room.code == expected_room
+    assert result.package.px.room == expected_room
+    assert result.package.poc.cross_id == "cross-room-test"
+
+
+def test_operational_chain_performs_four_roles_and_records_every_stage():
+    ledger = LRC2Ledger()
+    runtime = W3LguOperationalRuntime(ledger=ledger)
+
+    result = runtime.process_line(
+        "EVENT:route,TARGET:W3DB,ROOM:EV,PX:LNEV'0007,STATE:ready,CONF:1",
+        cross_id="cross-production",
+        timestamp="2026-06-15T00:00:00.000Z",
+    )
+
+    assert [stage.stage for stage in result.stages] == ["REDR", "PSP2", "DTML", "LRC2"]
+    assert result.stages[0].data["duplicate_to"] == ("PSP2", "LRC2")
+    assert result.stages[1].data["payload_changed"] is False
+    assert result.decision == "READY"
+    assert result.signal == "GREEN"
+    assert result.execute_allowed is False
+    assert len(result.lrc2_records) == 4
+    assert len(ledger) == 4
+    assert ledger.verify()
+
+
+def test_half_confidence_is_review_not_truth_or_failure():
+    result = W3LguOperationalRuntime().process_line(
+        "EVENT:observe,ROOM:AP,CONF:0.5",
+        cross_id="cross-half",
+    )
+
+    assert result.decision == "REVIEW"
+    assert result.signal == "YELLOW"
+    assert result.stages[2].data["reasons"] == ("CONFIDENCE_HALF",)
+
+
+def test_unresolved_marker_stops_but_is_still_recorded():
+    ledger = LRC2Ledger()
+    result = W3LguOperationalRuntime(ledger=ledger).process_line(
+        "EVENT:route!,TARGET:UNKNOWN,ROOM:EV",
+        cross_id="cross-stop",
+    )
+
+    assert result.decision == "STOP"
+    assert result.signal == "RED"
+    assert "UNRESOLVED_OR_HARMFUL_MARKER" in result.stages[2].data["reasons"]
+    assert result.stages[-1].status == "RECORDED"
+    assert len(ledger) == 4
+    assert ledger.verify()
+
+
+def test_lrc2_append_is_idempotent_and_hash_linked():
+    ledger = LRC2Ledger()
+    first = ledger.append(
+        event_id="EVT-1:REDR",
+        package_id="PKG-1",
+        stage="REDR",
+        status="PACKAGED",
+        payload={"value": 1},
+        timestamp="2026-06-15T00:00:00.000Z",
+    )
+    duplicate = ledger.append(
+        event_id="EVT-1:REDR",
+        package_id="PKG-CHANGED",
+        stage="REDR",
+        status="CHANGED",
+        payload={"value": 2},
+    )
+    second = ledger.append(
+        event_id="EVT-1:PSP2",
+        package_id="PKG-1",
+        stage="PSP2",
+        status="ROUTED",
+        payload={"value": 3},
+    )
+
+    assert duplicate is first
+    assert len(ledger) == 2
+    assert second.previous_hash == first.record_hash
+    assert ledger.verify()
+    with pytest.raises(FrozenInstanceError):
+        first.status = "EDITED"  # type: ignore[misc]
+
+
+def test_explicit_px_must_match_room_and_confidence_must_be_valid():
+    runtime = W3LguOperationalRuntime()
+
+    with pytest.raises(W3LguError, match="conflicts"):
+        runtime.process_line("EVENT:test,ROOM:CA,PX:LNEV'0001")
+    with pytest.raises(W3LguError, match="between 0 and 1"):
+        runtime.process_line("EVENT:test,CONF:2")
+
+
+@pytest.mark.parametrize(
+    "cross_id",
+    (
+        "cross'X0009",
+        "cross\nEVENT:forged",
+        "cross,STATE:STOP",
+        "cross:STATE:STOP",
+        " cross with spaces ",
+    ),
+)
+def test_poc_rejects_delimiter_unsafe_cross_ids(cross_id: str):
+    runtime = W3LguOperationalRuntime()
+
+    with pytest.raises(W3LguError, match="POC cross_id must use"):
+        runtime.process_line("EVENT:test", cross_id=cross_id)
+    with pytest.raises(W3LguError, match="POC cross_id must use"):
+        PointOfConvergence(cross_id, 1, 1)
+
+
+def test_operational_runtime_rejects_duplicate_governance_keys_before_recording():
+    ledger = LRC2Ledger()
+    runtime = W3LguOperationalRuntime(ledger=ledger)
+    packet = W3LguPacket(
+        (
+            W3LguPair("EVENT", "route"),
+            W3LguPair("STATE", "READY"),
+            W3LguPair("STATE", "STOP"),
+        ),
+        source="EVENT:route,STATE:READY,STATE:STOP",
+    )
+
+    with pytest.raises(W3LguError, match="keys must be unique: STATE"):
+        runtime.process_packet(packet, cross_id="cross-duplicate")
+    assert len(ledger) == 0
+
+
+def test_operational_runtime_rejects_duplicate_cross_id_from_text():
+    runtime = W3LguOperationalRuntime()
+
+    with pytest.raises(W3LguError, match="keys must be unique: CROSS_ID"):
+        runtime.process_line(
+            "EVENT:test,CROSS_ID:cross-safe,CROSS_ID:cross-other"
+        )
+
+
+def test_operational_runtime_validates_packet_cross_id_before_rendering_poc():
+    runtime = W3LguOperationalRuntime()
+
+    with pytest.raises(W3LguError, match="POC cross_id must use"):
+        runtime.process_line("EVENT:test,CROSS_ID:cross'X9999")
+
+
+def test_stable_derived_px_and_ids_make_replay_observable():
+    runtime = W3LguOperationalRuntime()
+    packet = parse_line("CAUSE:load,RESULT:slow,TARGET:QUEUE")
+
+    first = runtime.process_packet(packet, cross_id="cross-replay")
+    second = runtime.process_packet(packet, cross_id="cross-replay")
+
+    assert first.event_id == second.event_id
+    assert first.package.package_id == second.package.package_id
+    assert first.package.px == second.package.px
+    assert len(runtime.ledger) == 4
+    assert runtime.ledger.verify()

--- a/w3_api/adapters/w3lgu_adapter.py
+++ b/w3_api/adapters/w3lgu_adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from protocol.w3lgu import W3LguFiveLineProgram, parse_five_line_program, validate_five_line
+from protocol.w3lgu import W3LguFiveLineProgram, encode_w3lgu_value, parse_five_line_program, validate_five_line
 
 
 def build_cross_w3lgu_packet(
@@ -26,10 +26,10 @@ def build_cross_w3lgu_packet(
     contract = str(payload.get("contract", "observe_only"))
     text = "\n".join(
         (
-            f"MEM:SOURCE:{_clean(source)}",
-            f"PATCH:MODE:{_clean(mode)}",
-            f"LAW:TARGET:{_clean(target_value)},CONTRACT:{_clean(contract)}",
-            f"EVENT:INTENT:{_clean(intent)}",
+            f"MEM:SOURCE:{encode_w3lgu_value(source)}",
+            f"PATCH:MODE:{encode_w3lgu_value(mode)}",
+            f"LAW:TARGET:{encode_w3lgu_value(target_value)},CONTRACT:{encode_w3lgu_value(contract)}",
+            f"EVENT:INTENT:{encode_w3lgu_value(intent)}",
             "SIGNAL:STATUS:received,TRACEABLE:true",
         )
     )
@@ -38,9 +38,3 @@ def build_cross_w3lgu_packet(
     if not result.ok:
         raise ValueError(f"Invalid W3Lgu cross packet: {result.errors}")
     return program
-
-
-def _clean(value: str) -> str:
-    """Keep W3Lgu text single-line and packet-safe without changing meaning."""
-
-    return " ".join(str(value).replace("\n", " ").replace("\r", " ").split())

--- a/w3_api/models.py
+++ b/w3_api/models.py
@@ -32,11 +32,13 @@ class W3CrossPlanRequest(BaseModel):
 
     px: str = Field(..., min_length=1)
     paper_context: dict[str, Any] | None = None
+    include_box_suggestion: bool = False
 
 
 class W3CrossPlanResponse(BaseModel):
     """Safe dispatch plan from Cross-L dispatcher."""
 
+    contract_version: str = "1.0"
     state: str
     reason: str
     scope: str
@@ -49,3 +51,4 @@ class W3CrossPlanResponse(BaseModel):
     review: bool
     workset: dict[str, Any]
     safety: dict[str, bool]
+    suggested_template: dict[str, Any] | None = None

--- a/w3_api/router.py
+++ b/w3_api/router.py
@@ -58,7 +58,11 @@ def cross(req: W3CrossRequest) -> W3CrossResponse:
     )
 
 
-@router.post("/cross/plan", response_model=W3CrossPlanResponse)
+@router.post(
+    "/cross/plan",
+    response_model=W3CrossPlanResponse,
+    response_model_exclude_none=True,
+)
 def cross_plan(req: W3CrossPlanRequest) -> W3CrossPlanResponse:
     """Return a safe Cross-L dispatch plan from a PX reference.
 
@@ -66,5 +70,9 @@ def cross_plan(req: W3CrossPlanRequest) -> W3CrossPlanResponse:
     write repository files, merge changes, or call external systems.
     """
 
-    plan = dispatch_workset(req.px, paper_context=req.paper_context)
+    plan = dispatch_workset(
+        req.px,
+        paper_context=req.paper_context,
+        enable_box_suggestion=req.include_box_suggestion,
+    )
     return W3CrossPlanResponse(**plan)


### PR DESCRIPTION
### Motivation

- Introduce an immutable Event-Chain System (E-CS) to make Cross-X chain handoffs traceable without granting execution or mutation authority. 
- Provide a governed adapter for executing one MPCP Modew task and immutably binding its return into E-CS. 
- Add an operational W3Lgu runtime and safe encoding to support production semantics, unique IDs, and append-only LRC2 recording. 
- Surface optional read-only BOX template suggestions from the CROLL planner and expand CI to build and test the new modules. 

### Description

- Add a new `cross_x` subpackage including `event_chain.py` (E-CS dataclasses and builders), `mpcp_adapter.py` (approval model, handoff builder, executor adapter), and `audit.py` (configuration audit helper), and export new APIs via `cross_x.__init__`. 
- Extend `cross_x.core` to include E-CS integration, encode untrusted W3Lgu values with `encode_w3lgu_value`, call `build_event_chain`, and include `system_audit` in `CrossXPlan`. 
- Add `dispatch_cross_code` and E-CS identifier normalization plus optional BOX template suggestion to the CROLL planner (`croll/cross_l_dispatcher.py`) and expose a `--box-suggestion` CLI flag in `croll/cli.py`. 
- Add an operational W3Lgu implementation under `protocol/w3lgu/operational.py` (rooms, PX/POC, DTML/LRC2 flow, idempotent ledger, minimum laws), an encoding helper `protocol/w3lgu/encoding.py`, and extend `protocol/w3lgu` exports. 
- Add docs for the Cross→MPCP adapter and Cross-X ecosystem updates, and update READMEs. 
- Harden configuration loading and validation in `config/loader.py` to validate `event_chain_supervisor`, `chain` uniqueness, and `contracts` mapping, and update `config/cross_system.json` to include `event_chain_supervisor`. 
- Update W3-API adapter and router to safely encode external W3Lgu inputs, return optional `suggested_template` in plan responses, and add model fields to support suggestions. 
- Fix package-relative imports in `protocol/mpcp` runtime and contract modules. 
- Update GH Actions workflow `.github/workflows/croll.yml` to compile additional packages, run new test suites, and add a `box-api` job that validates BOX registry schema and runs `pytest` for integration tests. 

### Testing

- Ran CROLL unit tests with `python -m unittest discover -s croll -p

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba68fe81083329ff04fd5f2133738)